### PR TITLE
Fix Wemos D1 mini flash size

### DIFF
--- a/frameworks/arduino.rst
+++ b/frameworks/arduino.rst
@@ -3177,7 +3177,7 @@ WEMOS
       - 
       - ESP8266
       - 80 MHz
-      - 1024 Kb
+      - 4096 Kb
       - 80 Kb
 
     * - ``d1_mini_lite``

--- a/platforms/embedded_boards.rst
+++ b/platforms/embedded_boards.rst
@@ -4908,7 +4908,7 @@ WEMOS
       - 
       - ESP8266
       - 80 MHz
-      - 1024 Kb
+      - 4096 Kb
       - 80 Kb
 
     * - ``d1_mini_lite``

--- a/platforms/espressif8266.rst
+++ b/platforms/espressif8266.rst
@@ -497,7 +497,7 @@ WEMOS
       - 
       - ESP8266
       - 80 MHz
-      - 1024 Kb
+      - 4096 Kb
       - 80 Kb
 
     * - ``d1_mini_lite``


### PR DESCRIPTION
Flash size should be 4M according to https://wiki.wemos.cc/products:d1:d1_mini
and https://github.com/platformio/platform-espressif8266/blob/develop/boards/d1_mini.json