### PR TITLE
Correct default values for auto_update_libraries/platforms

### DIFF
--- a/userguide/cmd_settings.rst
+++ b/userguide/cmd_settings.rst
@@ -43,7 +43,7 @@ Settings
 ``auto_update_libraries``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Default:   Yes
+:Default:   No
 :Values:    Yes/No
 
 Automatically update libraries.
@@ -53,7 +53,7 @@ Automatically update libraries.
 ``auto_update_platforms``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Default:   Yes
+:Default:   No
 :Values:    Yes/No
 
 Automatically update platforms.


### PR DESCRIPTION
The docs say `auto_update_libraries` and `auto_update_platforms` are default `Yes`, but they're actually `No`.