### PR TITLE
Remove copy pasted parameter

### DIFF
--- a/plus/unit-testing.rst
+++ b/plus/unit-testing.rst
@@ -259,7 +259,7 @@ Summary of the `Unity Test API <https://github.com/ThrowTheSwitch/Unity#unity-te
 
 * `Running Tests <https://github.com/ThrowTheSwitch/Unity#running-tests>`_
 
-  - ``RUN_TEST(func, linenum)``
+  - ``RUN_TEST(func)``
 
 * `Ignoring Tests <https://github.com/ThrowTheSwitch/Unity#ignoring-tests>`_
 


### PR DESCRIPTION
Platformio does not support the line number parameter, this was copied over from the library's docs