### PR TITLE
faq.rst - fixed example command that incorrectly redirected output to a file that's only writeable by root

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -329,7 +329,7 @@ Please open system Terminal and type
 .. code-block:: bash
 
     # Recommended
-    sudo curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/scripts/99-platformio-udev.rules > /etc/udev/rules.d/99-platformio-udev.rules
+    curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
 
     # OR, manually download and copy this file to destination folder
     sudo cp 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules


### PR DESCRIPTION
Fixed example which incorrectly redirected output to a write-protected file