### PR TITLE
Document that RFDuino is unsupported

### DIFF
--- a/boards/nordicnrf51/rfduino.rst
+++ b/boards/nordicnrf51/rfduino.rst
@@ -64,6 +64,20 @@ board manifest `rfduino.json <https://github.com/platformio/platform-nordicnrf51
   board_build.f_cpu = 16000000L
 
 
+Unsupported
+~~~~~~~~~~~
+
+RFduino support has been dropped since PlatformIO switched to `arduino-nRF5 https://github.com/sandeepmistry/arduino-nRF5`. As a workaround, you can use the older version by specifying it explicitly:
+
+.. code-block:: ini
+
+   [env:rfduino]
+   platform = nordicnrf51@2.2.0
+   board = rfduino
+   framework = arduino
+   lib_deps = fastLED
+
+
 Uploading
 ---------
 RFduino supports the next uploading protocols:


### PR DESCRIPTION
Source: [this answer on the forums](https://community.platformio.org/t/fatal-error-rfduinoble-h-no-such-file-or-directory/2441/4) by @ivankravets 

I have a RFD22102 RFDuino board, equipment choice decided by external factors, with the USB FTDI dongle. Following the docs led me to a state where I could compile fine, but not upload. None of the available uploaders were relevant to me, as I don't have, nor need, the specialized debuggers. I was also unsuccessful in coercing the vendor-supplied RFDLoader to work.

The linked answer solved all my issues, and I think this info needs to be in the docs outright.