### PR TITLE
Spelling

### DIFF
--- a/ci/circleci.rst
+++ b/ci/circleci.rst
@@ -110,7 +110,7 @@ Manually download dependent library and include in build process via ``--lib`` o
 Custom Build Flags
 ~~~~~~~~~~~~~~~~~~
 
-PlatformIO allows to specify own build flags using :envvar:`PLATFORMIO_BUILD_FLAGS` environment
+PlatformIO allows one to specify own build flags using :envvar:`PLATFORMIO_BUILD_FLAGS` environment
 
 .. code-block:: yaml
 
@@ -126,7 +126,7 @@ For the more details, please follow to
 Advanced configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-PlatformIO allows to configure multiple build environments for the single
+PlatformIO allows one to configure multiple build environments for the single
 source code using :ref:`projectconf`.
 
 Instead of ``--board`` option, please use :option:`platformio ci --project-conf`

--- a/ci/travis.rst
+++ b/ci/travis.rst
@@ -134,7 +134,7 @@ Manually download dependent library and include in build process via ``--lib`` o
 Custom Build Flags
 ------------------
 
-PlatformIO allows to specify own build flags using :envvar:`PLATFORMIO_BUILD_FLAGS` environment
+PlatformIO allows one to specify own build flags using :envvar:`PLATFORMIO_BUILD_FLAGS` environment
 
 .. code-block:: yaml
 
@@ -155,7 +155,7 @@ For the more details, please follow to
 Advanced configuration
 ----------------------
 
-PlatformIO allows to configure multiple build environments for the single
+PlatformIO allows one to configure multiple build environments for the single
 source code using :ref:`projectconf`.
 
 Instead of ``--board`` option, please use :option:`platformio ci --project-conf`

--- a/envvars.rst
+++ b/envvars.rst
@@ -54,7 +54,7 @@ PlatformIO uses it to disable prompts and progress bars. In other words,
 
 .. envvar:: PLATFORMIO_AUTH_TOKEN
 
-Allows to specify Personal Authentication Token that could be used for
+Allows one to specify Personal Authentication Token that could be used for
 automatic login in to :ref:`pioaccount`. It is very useful for :ref:`ci`
 systems and :ref:`pioremote` operations where you are not able manually authorize.
 
@@ -74,50 +74,50 @@ The possible values are ``true`` and ``false``. Default is ``PLATFORMIO_DISABLE_
 
 .. envvar:: PLATFORMIO_HOME_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_home_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_home_dir`.
 
 .. envvar:: PLATFORMIO_INCLUDE_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_include_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_include_dir`.
 
 .. envvar:: PLATFORMIO_SRC_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_src_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_src_dir`.
 
 .. envvar:: PLATFORMIO_LIB_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_lib_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_lib_dir`.
 
 .. envvar:: PLATFORMIO_LIBDEPS_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_libdeps_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_libdeps_dir`.
 
 .. envvar:: PLATFORMIO_BUILD_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_build_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_build_dir`.
 
 .. envvar:: PLATFORMIO_DATA_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_data_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_data_dir`.
 
 .. envvar:: PLATFORMIO_TEST_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_test_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_test_dir`.
 
 .. envvar:: PLATFORMIO_BOARDS_DIR
 
-Allows to override :ref:`projectconf` option :ref:`projectconf_pio_boards_dir`.
+Allows one to override :ref:`projectconf` option :ref:`projectconf_pio_boards_dir`.
 
 .. envvar:: PLATFORMIO_REMOTE_AGENT_DIR
 
-Allows to override :option:`platformio remote agent start --working-dir`.
+Allows one to override :option:`platformio remote agent start --working-dir`.
 
 Building
 --------
 
 .. envvar:: PLATFORMIO_BUILD_FLAGS
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_build_flags`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_build_flags`.
 
 Examples:
 
@@ -135,19 +135,19 @@ Examples:
 
 .. envvar:: PLATFORMIO_SRC_BUILD_FLAGS
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_src_build_flags`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_src_build_flags`.
 
 .. envvar:: PLATFORMIO_SRC_FILTER
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_src_filter`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_src_filter`.
 
 .. envvar:: PLATFORMIO_EXTRA_SCRIPTS
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_extra_scripts`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_extra_scripts`.
 
 .. envvar:: PLATFORMIO_LIB_EXTRA_DIRS
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_lib_extra_dirs`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_lib_extra_dirs`.
 
 
 Uploading
@@ -155,55 +155,55 @@ Uploading
 
 .. envvar:: PLATFORMIO_UPLOAD_PORT
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_upload_port`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_upload_port`.
 
 .. envvar:: PLATFORMIO_UPLOAD_FLAGS
 
-Allows to set :ref:`projectconf` option :ref:`projectconf_upload_flags`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_upload_flags`.
 
 
 Settings
 --------
 
-Allows to override PlatformIO settings. You can manage them via
+Allows one to override PlatformIO settings. You can manage them via
 :ref:`cmd_settings` command.
 
 .. envvar:: PLATFORMIO_SETTING_AUTO_UPDATE_LIBRARIES
 
-Allows to override setting :ref:`setting_auto_update_libraries`.
+Allows one to override setting :ref:`setting_auto_update_libraries`.
 
 .. envvar:: PLATFORMIO_SETTING_AUTO_UPDATE_PLATFORMS
 
-Allows to override setting :ref:`setting_auto_update_platforms`.
+Allows one to override setting :ref:`setting_auto_update_platforms`.
 
 .. envvar:: PLATFORMIO_SETTING_CHECK_LIBRARIES_INTERVAL
 
-Allows to override setting :ref:`setting_check_libraries_interval`.
+Allows one to override setting :ref:`setting_check_libraries_interval`.
 
 .. envvar:: PLATFORMIO_SETTING_CHECK_PLATFORMIO_INTERVAL
 
-Allows to override setting :ref:`setting_check_platformio_interval`.
+Allows one to override setting :ref:`setting_check_platformio_interval`.
 
 .. envvar:: PLATFORMIO_SETTING_CHECK_PLATFORMS_INTERVAL
 
-Allows to override setting :ref:`setting_check_platforms_interval`.
+Allows one to override setting :ref:`setting_check_platforms_interval`.
 
 .. envvar:: PLATFORMIO_SETTING_ENABLE_CACHE
 
-Allows to override setting :ref:`setting_enable_cache`.
+Allows one to override setting :ref:`setting_enable_cache`.
 
 .. envvar:: PLATFORMIO_SETTING_ENABLE_SSL
 
-Allows to override setting :ref:`setting_enable_ssl`.
+Allows one to override setting :ref:`setting_enable_ssl`.
 
 .. envvar:: PLATFORMIO_SETTING_ENABLE_TELEMETRY
 
-Allows to override setting :ref:`setting_enable_telemetry`.
+Allows one to override setting :ref:`setting_enable_telemetry`.
 
 .. envvar:: PLATFORMIO_SETTING_FORCE_VERBOSE
 
-Allows to override setting :ref:`setting_force_verbose`.
+Allows one to override setting :ref:`setting_force_verbose`.
 
 .. envvar:: PLATFORMIO_SETTING_PROJECTS_DIR
 
-Allows to override setting :ref:`setting_projects_dir`.
+Allows one to override setting :ref:`setting_projects_dir`.

--- a/frameworks/mbed_extra.rst
+++ b/frameworks/mbed_extra.rst
@@ -70,7 +70,7 @@ Build profiles
 
 By default, PlatformIO builds your project using ``develop profile`` which provides optimized 
 firmware size with full error information and allows MCU to go to sleep mode. In the case when
-defalt build profile is not suitable for your project there two other profiles ``release`` and
+default build profile is not suitable for your project there two other profiles ``release`` and
 ``debug`` that can be enabled using special macro definitions. You can change build profile 
 :ref:`projectconf_build_flags` of :ref:`projectconf`:
 

--- a/ide/atom.rst
+++ b/ide/atom.rst
@@ -38,7 +38,7 @@ Installation
     if you are going to use :ref:`ide_atom`. :ref:`piocore` is built into
     PlatformIO IDE and you will be able to use it within PlatformIO IDE Terminal.
 
-    Also, PlatformIO IDE allows to install :ref:`piocore` Shell Commands
+    Also, PlatformIO IDE allows one to install :ref:`piocore` Shell Commands
     (``pio``, ``platformio``) globally to your system via
     ``Menu: PlatformIO > Install Shell Commands``.
 

--- a/ide/clion.rst
+++ b/ide/clion.rst
@@ -89,7 +89,7 @@ the screenshot above):
   see :ref:`platform_espressif_uploadfs`
 * ``PLATFORMIO_UPDATE`` - Update installed platforms and libraries via :ref:`cmd_update`
 * ``PLATFORMIO_REBUILD_PROJECT_INDEX`` - Rebuild C/C++ Index for the Project.
-  Allows to fix code completion and code linting issues.
+  Allows one to fix code completion and code linting issues.
 
 .. warning::
     The libraries which are added, installed or used in the project

--- a/ide/cloud9.rst
+++ b/ide/cloud9.rst
@@ -120,7 +120,7 @@ Let's create our first PlatformIO-based Cloud9 Project
 PlatformIO Build System
 -----------------------
 
-Cloud9 allows to create own build system and use hotkey or command
+Cloud9 allows one to create own build system and use hotkey or command
 (Menu: Run > Build) to build a project.
 
 Let's create PlatformIO Build System that will be used for C/C++/H/INO/PDE

--- a/ide/eclipse.rst
+++ b/ide/eclipse.rst
@@ -73,7 +73,7 @@ Then:
    + ``PlatformIO: Update platforms and libraries`` - Update installed
      platforms and libraries via :ref:`cmd_update`
    + ``PlatformIO: Rebuild C/C++ Project Index`` - Rebuild C/C++ Index for the Project.
-     Allows to fix code completion and code linting issues.
+     Allows one to fix code completion and code linting issues.
 
 If you have some problems with unresolved includes, defines, etc., then
 

--- a/ide/sublimetext.rst
+++ b/ide/sublimetext.rst
@@ -127,7 +127,7 @@ After that, we can use the necessary commands from
 Command Hotkeys
 '''''''''''''''
 
-Sublime Text allows to bind own hotkey per command. Let's setup them
+Sublime Text allows one to bind own hotkey per command. Let's setup them
 for PlatformIO commands using shortcut ``Menu: Preferences > Key-Bindings - User``:
 
 .. image:: ../_static/images/ide/sublimetext/ide-sublimetext-newproject-3.png

--- a/ide/visualstudio.rst
+++ b/ide/visualstudio.rst
@@ -156,7 +156,7 @@ Known issues
 IntelliSense Errors
 ^^^^^^^^^^^^^^^^^^^
 
-VS Studio does not allow to specify for project other toolchain which will
+VS Studio does not allow one to specify for project other toolchain which will
 be used by IntelliSense. In this case, IntelliSense does not understand
 GCC-specific definitions.
 

--- a/librarymanager/config.rst
+++ b/librarymanager/config.rst
@@ -280,7 +280,7 @@ Home page of library (if is different from :ref:`libjson_repository` url).
 
 Explain PlatformIO Library Crawler which content from the repository/archive
 should be exported as "source code" of the library. This option is useful if
-need to exclude extra data (test code, docs, images, PDFs, etc). It allows to
+need to exclude extra data (test code, docs, images, PDFs, etc). It allows one to
 reduce size of the final archive.
 
 Possible options:

--- a/librarymanager/ldf.rst
+++ b/librarymanager/ldf.rst
@@ -144,7 +144,7 @@ there are 2 libraries:
 Compatibility Mode
 ------------------
 
-Compatibility mode allows to control strictness of Library Dependency Finder.
+Compatibility mode allows one to control strictness of Library Dependency Finder.
 If library contains one of manifest file (:ref:`library_config`,
 ``library.properties``, ``module.json``), then LDF check compatibility of this
 library with real build environment. Available compatibility modes:

--- a/librarymanager/quickstart.rst
+++ b/librarymanager/quickstart.rst
@@ -35,7 +35,7 @@ storage in :ref:`projectconf_pio_libdeps_dir`.
 Project dependencies
 --------------------
 
-*PlatformIO Library Manager* allows to specify project dependencies
+*PlatformIO Library Manager* allows one to specify project dependencies
 (:ref:`projectconf_lib_deps`) that will be installed automatically per project
 before environment processing. You do not need to install libraries manually.
 The only one simple step is to define dependencies in :ref:`projectconf`.

--- a/migration.rst
+++ b/migration.rst
@@ -122,7 +122,7 @@ updated commands and options.
     * - :option:`platformio lib install --silent`
       - Suppress progress reporting when install library
     * - :option:`platformio lib install --interactive`
-      - Allow to make a choice for all prompts when install library
+      - Allow one to make a choice for all prompts when install library
     * - :option:`platformio lib search --header`
       - Search library by specific header file name (include)
     * - :option:`platformio lib update --only-check`

--- a/migration.rst
+++ b/migration.rst
@@ -167,7 +167,7 @@ updated options.
       - Specify project dependencies that should be installed automatically to :ref:`projectconf_pio_libdeps_dir` before environment processing.
     * - env
       - :ref:`projectconf_env_platform`
-      - PlatformIO 3.0 allows to use specific version of platform using `Semantic Versioning <http://semver.org>`_ (X.Y.Z=MAJOR.MINOR.PATCH).
+      - PlatformIO 3.0 allows one to use specific version of platform using `Semantic Versioning <http://semver.org>`_ (X.Y.Z=MAJOR.MINOR.PATCH).
     * - env
       - :ref:`projectconf_lib_extra_dirs`
       - A list with extra directories/storages where :ref:`ldf` will look for dependencies
@@ -176,7 +176,7 @@ updated options.
       - This option specifies how does :ref:`ldf` should analyze dependencies (``#include`` directives)
     * - env
       - :ref:`projectconf_lib_compat_mode`
-      - Library compatibility mode allows to control strictness of :ref:`ldf`
+      - Library compatibility mode allows one to control strictness of :ref:`ldf`
     * - env
       - :ref:`projectconf_test_ignore`
       - Ignore tests where the name matches specified patterns

--- a/platforms/creating_board.rst
+++ b/platforms/creating_board.rst
@@ -20,7 +20,7 @@ list is available:
 * `Embedded Boards Explorer <https://platformio.org/boards>`_ (Web)
 * :ref:`cmd_boards` (CLI command)
 
-Nevertheless, PlatformIO allows to create own board or override existing
+Nevertheless, PlatformIO allows one to create own board or override existing
 board's settings. All data is declared using
 `JSON-style <http://en.wikipedia.org/wiki/JSON>`_ via
 `associative array <http://en.wikipedia.org/wiki/Associative_array>`_

--- a/plus/pio-remote.rst
+++ b/plus/pio-remote.rst
@@ -107,10 +107,10 @@ role from anywhere in the world.
 
 |PIORemote| is multi-agents and multi-clients system. A single agent can be
 shared with multiple clients, where different clients can use the same agent.
-This approach allows to work with distributed hardware located in the different
+This approach allows one to work with distributed hardware located in the different
 places, networks, etc.
 
-This technology allows to work with remote devices in generic form as you
+This technology allows one to work with remote devices in generic form as you
 do that with local devices using PlatformIO ecosystem. The only one difference
 is a prefix "remote" before each generic PlatformIO command. For example,
 listing of local and remote devices will look like :ref:`cmd_device_list` and

--- a/projectconf/advanced_scripting.rst
+++ b/projectconf/advanced_scripting.rst
@@ -35,7 +35,7 @@ Advanced Scripting
 
 .. contents::
 
-PlatformIO Build System allows to extend build process with the custom
+PlatformIO Build System allows one to extend build process with the custom
 :ref:`projectconf_extra_scripts` using Python interpreter and
 `SCons <http://www.scons.org>`_ construction tool.
 Build and upload flags, targets, toolchains data, and other information are
@@ -156,7 +156,7 @@ data or add new.
 Before/Pre and After/Post actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PlatformIO Build System has rich API that allows to attach different pre-/post
+PlatformIO Build System has rich API that allows one to attach different pre-/post
 actions (hooks) using ``env.AddPreAction(target, callback)`` or
 ``env.AddPreAction(target, [callback1, callback2, ...])`` function. A first
 argument ``target`` can be a name of target that is passed using

--- a/projectconf/section_env_build.rst
+++ b/projectconf/section_env_build.rst
@@ -154,7 +154,7 @@ see ALL variables from a build environment.
 Dynamic build flags
 '''''''''''''''''''
 
-PlatformIO allows to run external command/script which outputs build flags
+PlatformIO allows one to run external command/script which outputs build flags
 into STDOUT. PlatformIO will automatically parse this output and append flags
 to a build environment.
 
@@ -237,7 +237,7 @@ Remove base/initial flags which were set by development platform.
 ``src_filter``
 ^^^^^^^^^^^^^^
 
-This option allows to specify which source files should be included/excluded
+This option allows one to specify which source files should be included/excluded
 from build process. Filter supports 2 templates:
 
 * ``+<PATH>`` include template

--- a/projectconf/section_env_debug.rst
+++ b/projectconf/section_env_debug.rst
@@ -159,7 +159,7 @@ device. Possible options:
 ``debug_load_mode``
 ^^^^^^^^^^^^^^^^^^^
 
-Allows to control when PlatformIO should load debugging firmware to the end
+Allows one to control when PlatformIO should load debugging firmware to the end
 target. Possible options:
 
 * ``always`` - load for the each debugging session, **default**
@@ -172,7 +172,7 @@ target. Possible options:
 ``debug_server``
 ^^^^^^^^^^^^^^^^
 
-Allows to setup a custom debugging server. By default, boards are pre-configured
+Allows one to setup a custom debugging server. By default, boards are pre-configured
 with a debugging server that is compatible with "on-board" debugging tool
 (adapter, probe). Also, this option is useful for a
 :ref:`debugging_tool_custom` debugging tool.

--- a/projectconf/section_env_general.rst
+++ b/projectconf/section_env_general.rst
@@ -24,7 +24,7 @@ General options
 
 :ref:`platforms` name.
 
-PlatformIO allows to use specific version of platform using
+PlatformIO allows one to use specific version of platform using
 `Semantic Versioning <http://semver.org>`_ (X.Y.Z=MAJOR.MINOR.PATCH) or VCS
 (Git, Mercurial and Subversion).
 

--- a/projectconf/section_env_library.rst
+++ b/projectconf/section_env_library.rst
@@ -180,7 +180,7 @@ Example:
 .. seealso::
     Please make sure to read :ref:`ldf` guide first.
 
-Library compatibility mode allows to control strictness of Library Dependency
+Library compatibility mode allows one to control strictness of Library Dependency
 Finder. More details :ref:`ldf_compat_mode`.
 
 By default, this value is set to ``lib_compat_mode = soft`` and means that LDF

--- a/projectconf/section_platformio.rst
+++ b/projectconf/section_platformio.rst
@@ -41,7 +41,7 @@ Describe a project with a short information. PlatformIO uses it for
 
 :ref:`cmd_run` command processes all environments ``[env:***]`` by default
 if :option:`platformio run --environment` option is not specified.
-:ref:`projectconf_pio_env_default` allows to define environments which
+:ref:`projectconf_pio_env_default` allows one to define environments which
 should be processed by default.
 
 Also, :ref:`piodebug` checks this option when looking for debug environment.

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -23,7 +23,7 @@ Setting Up the Project
 ----------------------
 
 :ref:`piocore` provides special :ref:`cmd_init` command for configuring your projects.
-It allows to initialize new empty project or update existing with the new data.
+It allows one to initialize new empty project or update existing with the new data.
 
 What is more, :ref:`cmd_init` can be used for :ref:`ide`. It means that you will
 be able to import pre-generated PlatformIO project using favorite IDE and

--- a/userguide/cmd_ci.rst
+++ b/userguide/cmd_ci.rst
@@ -48,7 +48,7 @@ For more details as for integration with the popular Continuous Integration
 Systems please follow to :ref:`ci` page.
 
 .. note::
-    :ref:`cmd_ci` command is useful for library developers. It allows to build
+    :ref:`cmd_ci` command is useful for library developers. It allows one to build
     different examples without creating own project per them. Also, is possible
     to upload firmware to the target device. In this case, you need to pass
     additional option ``--project-option="targets=upload"``. What is more,

--- a/userguide/lib/cmd_install.rst
+++ b/userguide/lib/cmd_install.rst
@@ -108,7 +108,7 @@ Suppress progress reporting
 .. option::
     --interactive
 
-Allow to make a choice for all prompts
+Allow one to make a choice for all prompts
 
 .. option::
     -f, --force


### PR DESCRIPTION
Not sure if you want to merge this one like it is right now. Debian lintian is reporting spelling errors as you can see at https://mentors.debian.net/package/platformio. I've used sed to replace all occurences.