### PR TITLE
Mention Java dependency for dfu mode

### DIFF
--- a/boards/ststm32/maple_mini_origin.rst
+++ b/boards/ststm32/maple_mini_origin.rst
@@ -76,6 +76,10 @@ Maple Mini Original supports the next uploading protocols:
 
 Default protocol is ``dfu``
 
+.. warning::
+    You may need to install Java depending on your system configuration when
+    using the dfu upload protocol.
+
 You can change upload protocol using :ref:`projectconf_upload_protocol` option:
 
 .. code-block:: ini


### PR DESCRIPTION
... otherwise, the user will get a nice 

```
'java' is not recognized as an internal or external command,
operable program or batch file.
```

when trying to upload on a system without Java already installed...

Not sure the prefered style of showing this notice, but the 'warning' style was used further down the page with regards to installing debug drivers...