### PR TITLE
Link to master branch version of udev rules

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -228,7 +228,7 @@ instead.
 
 Linux users have to install `udev <https://en.wikipedia.org/wiki/Udev>`_ rules
 for PlatformIO supported boards/devices. The
-latest version of rules may be found at https://raw.githubusercontent.com/platformio/platformio-core/develop/scripts/99-platformio-udev.rules
+latest version of rules may be found at https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules
 
 .. note::
   Please check that your board's PID and VID  are listed in the rules.
@@ -244,7 +244,7 @@ Please open system Terminal and type
 .. code-block:: bash
 
     # Recommended
-    curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
+    curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
 
     # OR, manually download and copy this file to destination folder
     sudo cp 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules


### PR DESCRIPTION
Since this is the master branch, link to the master branch version of the udev rules

Context / question: If my understanding of how PlatformIO does the [udev rules check](https://github.com/platformio/platformio-core/blob/bd3b29c304cdd01482aea8d2d161a465dcfd6cec/platformio/util.py#L481-L509) is correct, it is comparing a bundled version of the udev rules with the copy installed on the system. Because the documentation for the stable version links to the `develop` branch, people are downloading the wrong copy of the udev rules if they are still on the stable version. Is this an bug / oversight, or am I missing something here?

Related forum post: https://community.platformio.org/t/warning-please-install-99-platformio-udev-rules-keeps-showing-up/773/21