### PR TITLE
Add build-flag note for mbed.

### DIFF
--- a/platforms/nordicnrf52.rst
+++ b/platforms/nordicnrf52.rst
@@ -258,6 +258,9 @@ Frameworks
 
     * - :ref:`framework_mbed`
       - The mbed framework The mbed SDK has been designed to provide enough hardware abstraction to be intuitive and concise, yet powerful enough to build complex projects. It is built on the low-level ARM CMSIS APIs, allowing you to code down to the metal if needed. In addition to RTOS, USB and Networking libraries, a cookbook of hundreds of reusable peripheral and module libraries have been built on top of the SDK by the mbed Developer Community.
+     
+Note: You have to set `build_flags = -DPIO_FRAMEWORK_MBED_RTOS_PRESENT` in your `platformio.ini` to enable some of the mbed framework features and include files.
+
 
 Boards
 ------


### PR DESCRIPTION
The Arduino tutorial has a section which lets you know you have to set the build flags, but there is no such thing for mbed. Being a noob, I was trying to find why even the copy/pasted examples were failing in mbed. And found out I have to add the flag when looking at the example's .ini file.

I think adding this note would be helpful to people getting started. Please feel free to modify the commit if you feel it could be done better.