### PR TITLE
add windows users tips for OTA

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -408,6 +408,11 @@ For the full list with available options please run
         -d, --debug         Show debug output. And override loglevel with debug.
         -r, --progress      Show progress output. Does not work for ArduinoIDE
 
+.. warning::
+    For windows users. To manage OTA check the ESP wifi network profile isn't checked on public
+    be sure it's on private mode``
+
+
 Using Arduino Framework with Staging version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi there!

I wasted my time on ridiculous thing about OTA. I'd like to make OTA on AP or STA mode and i trying trying trying again and again with no success. By searching through the web i get the answer. On windows ESP AP network are tagged in public mode ans this block the OTA process. Just have to change it on private and manage the OTA through AP, STA and both modes.

So i think a little tip can help many users.