### PR TITLE
mbed-rtos example no longer exists for Teensy

### DIFF
--- a/platforms/teensy.rst
+++ b/platforms/teensy.rst
@@ -38,7 +38,6 @@ Examples are listed from `Teensy development platform repository <https://github
 * `mbed-blink <https://github.com/platformio/platform-teensy/tree/master/examples/mbed-blink?utm_source=platformio&utm_medium=docs>`_
 * `mbed-dsp <https://github.com/platformio/platform-teensy/tree/master/examples/mbed-dsp?utm_source=platformio&utm_medium=docs>`_
 * `mbed-events <https://github.com/platformio/platform-teensy/tree/master/examples/mbed-events?utm_source=platformio&utm_medium=docs>`_
-* `mbed-rtos <https://github.com/platformio/platform-teensy/tree/master/examples/mbed-rtos?utm_source=platformio&utm_medium=docs>`_
 * `mbed-serial <https://github.com/platformio/platform-teensy/tree/master/examples/mbed-serial?utm_source=platformio&utm_medium=docs>`_
 
 Debugging


### PR DESCRIPTION
Was removed in platformio/platform-teensy/commit/f0f279185e6a228527fe65a65cc6a967678b7e1a#diff-bfebe34154a0dfd9fc7b447fc9ed74e9

Credit for finding: mikemoy https://community.platformio.org/t/full-support-for-teensy-4-0-build-test-debug-with-platformio/9249/4