### PR TITLE
Add uucp group

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -276,6 +276,13 @@ they are not “root”, doing this issuing
     sudo usermod -a -G dialout $USER
     sudo usermod -a -G plugdev $USER
 
+Similarly, Arch users may need to add their user to the “uucp” group
+
+.. code-block:: bash
+
+    sudo usermod -a -G uucp $USER
+    sudo usermod -a -G lock $USER
+
 .. note::
   You will need to log out and log back in again (or reboot) for the user
   group changes to take effect.


### PR DESCRIPTION
As stated in the [ArchWiki](https://wiki.archlinux.org/index.php/Arduino#Accessing_serial):

> Udev creates files such as `/dev/ttyUSB0` owned by group `uucp` so adding the user to the `uucp` group gives the required read/write access. Also, if you are planning to use the default Java IDE, add your user to the `lock` group for `/var/lock/lockdev` access.

This adds a mention of the `uucp` and `lock` group below Debian/Ubuntu instructions in the FAQ.