### PR TITLE
Fix broken link fto esp-idf partition table utility docs

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -174,7 +174,7 @@ See `project example <https://github.com/platformio/platform-espressif32/tree/de
 
 Partition Tables
 ~~~~~~~~~~~~~~~~
-You can create a custom partitions table (CSV) following `ESP32 Partition Tables <http://esp-idf.readthedocs.io/en/v3.0/api-guides/partition-tables.html>`_
+You can create a custom partitions table (CSV) following `ESP32 Partition Tables <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/storage/nvs_partition_gen.html>`_
 documentation. PlatformIO uses **default partition tables** depending on a
 :ref:`projectconf_env_framework` type:
 


### PR DESCRIPTION
The link to the partition table tool under platforms > espressif32 points to a url that seems to be auth protected to the project maintainers. It looks like the uri scheme for esp-idf and other espressif projects may have changed. 

Looks like they also added quite a few pages on partition tables and storage, so I pointed to the csv utility which is what I believe this documents purpose is for.

I also updated the link to use the `latest` api segment instead of `v3`.