### PR TITLE
Fix typos and some Mega/Mini/MightyCore naming errors

### DIFF
--- a/platforms/atmelavr.rst
+++ b/platforms/atmelavr.rst
@@ -17,7 +17,7 @@ Atmel AVR
 :Configuration:
   :ref:`projectconf_env_platform` = ``atmelavr``
 
-Atmel AVR 8- and 32-bit MCUs deliver a unique combination of performance, power efficiency and design flexibility. Optimized to speed time to market-and easily adapt to new ones-they are based on the industrys most code-efficient architecture for C and assembly programming.
+Atmel AVR 8-bit MCUs deliver a unique combination of performance, power efficiency and design flexibility. Optimized to speed time to market-and easily adapt to new ones-they are based on the industry's most code-efficient architecture for C and assembly programming.
 
 For more detailed information please visit `vendor site <http://www.atmel.com/products/microcontrollers/avr/default.aspx?utm_source=platformio&utm_medium=docs>`_.
 
@@ -101,13 +101,13 @@ Packages
       - Arduino Wiring-based Framework (Dwenguino Core)
 
     * - `framework-arduino-avr-megacore <https://github.com/MCUdude/MegaCore?utm_source=platformio&utm_medium=docs>`__
-      - Arduino Wiring-based Framework (megaCore Core)
+      - Arduino Wiring-based Framework (MegaCore)
 
     * - `framework-arduino-avr-mightycore <https://github.com/MCUdude/MightyCore?utm_source=platformio&utm_medium=docs>`__
-      - Arduino Wiring-based Framework (MightyCore Core)
+      - Arduino Wiring-based Framework (MightyCore)
 
     * - `framework-arduino-avr-minicore <https://github.com/MCUdude/MiniCore?utm_source=platformio&utm_medium=docs>`__
-      - Arduino Wiring-based Framework (MiniCore Core)
+      - Arduino Wiring-based Framework (MiniCore)
 
     * - `framework-arduino-avr-nicai <https://github.com/arduino/ArduinoCore-avr?utm_source=platformio&utm_medium=docs>`__
       - Arduino Wiring-based Framework (Nicai Core)

--- a/platforms/atmelavr_extra.rst
+++ b/platforms/atmelavr_extra.rst
@@ -171,10 +171,10 @@ Custom fuse values and upload flags (based on upload protocol) should be specifi
         -b$UPLOAD_SPEED
         -e
 
-Mini, Mega, Mighty cores
-^^^^^^^^^^^^^^^^^^^^^^^^
+MiniCore, MegaCore and MightyCore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``Mini``, ``Mega``, ``Mighty`` cores support dynamic fuses generation. Generated values are based on the next parameters:
+``MiniCore``, ``MegaCore`` and ``MightyCore`` support dynamic fuses generation. Generated values are based on the next parameters:
 
   .. list-table::
     :header-rows:  1
@@ -290,10 +290,9 @@ Custom bootloader and corresponding fuses should be specified in :ref:`projectco
     board_bootloader.unlock_bits = 0x3F
 
 
-Mini, Mega, Mighty cores
-^^^^^^^^^^^^^^^^^^^^^^^^
+https://github.com/MCUdude/platformio-docs
 
-``Mini``, ``Mega``, ``Mighty`` cores have a wide variety of precompiled bootloaders. Bootloader binary is dynamically selected according to the hardware parameters: ``f_cpu``, ``oscillator``, ``upload_speed``:
+``MiniCore``, ``MegaCore`` and ``MightyCore`` have a wide variety of precompiled bootloaders. Bootloader binary is dynamically selected according to the hardware parameters: ``f_cpu``, ``oscillator``, ``upload_speed``:
 
   .. list-table::
     :header-rows:  1


### PR DESCRIPTION
Just some minor errors I found while reading through the docs.