### PR TITLE
Various clarifications and readability improvements

### DIFF
--- a/boards/index.rst
+++ b/boards/index.rst
@@ -14,21 +14,25 @@
 Boards
 ======
 
-Rapid Embedded Development, Continuous and IDE integration in a few
-steps with PlatformIO thanks to built-in project generator for the most
-popular embedded boards and IDE.
+Enjoy rapid embedded development with Continuous Integration and IDE
+integration after just a few setup steps with PlatformIO thanks to the
+built-in project generator for the most popular embedded boards and
+IDEs.
 
 .. note::
-    * You can list pre-configured boards by :ref:`cmd_boards` command or
-      `PlatformIO Boards Explorer <https://platformio.org/boards>`_
-    * For more detailed ``board`` information please scroll tables below by horizontal.
+    * You can list all pre-configured boards by the :ref:`cmd_boards`
+      command-line command or through the `PlatformIO Boards Explorer
+      <https://platformio.org/boards>`_
+    * To define your own board, see `Custom Embedded Boards <https://platformio.org/platforms/creating_board.html>`_
+
+For detailed information on the generally available ``board`` options, please see the list below:
 
 Aceinna IMU
 -----------
 
 .. toctree::
     :maxdepth: 1
-        
+
     aceinna_imu/LowCostRTK
     aceinna_imu/OpenIMU300
     aceinna_imu/OpenIMU300ZA

--- a/ide/vscode.rst
+++ b/ide/vscode.rst
@@ -41,7 +41,7 @@ Installation
 
 0. `Download <https://code.visualstudio.com>`_ and install official Microsoft Visual Studio Code. PlatformIO IDE is built on top of it
 1. **Open** VSCode Package Manager
-2. **Search** for official ``platformio ide`` `extension <https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide>`_
+2. **Search** for the official ``platformio ide`` `extension <https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide>`_
 3. **Install** PlatformIO IDE.
 
 .. image:: ../_static/images/ide/vscode/platformio-ide-vscode-pkg-installer.png
@@ -175,8 +175,8 @@ Task Explorer
 ~~~~~~~~~~~~~
 
 PlatformIO provides access to "Project Task Explorer" where you can control
-build process of declared environments in :ref:`projectconf`.
-Project Task Explorer is located in VSCode Activity Bar under branded
+the build process of the environments declared in :ref:`projectconf`.
+Project Task Explorer is located in the VSCode Activity Bar under the branded
 PlatformIO icon. You can also access it via "VSCode Menu > Open View... >
 PlatformIO".
 
@@ -185,20 +185,24 @@ PlatformIO".
 Task Runner
 ~~~~~~~~~~~
 
-PlatformIO IDE provides base tasks ``Menu > Termina > Run Task...`` (Build,
+PlatformIO IDE provides built-in tasks through the menu ``Terminal > Run Task...`` (Build,
 Upload, Clean, Monitor, etc) and custom tasks per :ref:`projectconf` environment
-(``[env:***]``). A default behavior is to use Terminal Panel for presentation.
-Also, we use dedicated panel per unique task.
+(``[env:***]``). The default behavior is to use Terminal Panels for presentation,
+one panel dedicated to each unique task.
 
-PlatformIO IDE provides own Problems Matcher named ``$platformio``.
-You can use it later if decide to change base task settings.
+The PlatformIO IDE provides its own Problems Matcher named ``$platformio``.
+You can use it later if you decide to change base task settings.
 
-You can override existing task with own presentation options. For example,
-let configure PlatformIO Task Runner to use NEW Terminal panel per each "Build"
+You can override existing tasks with your own presentation options. For example,
+let's configure PlatformIO Task Runner to use a NEW Terminal panel for each "Build"
 command:
 
-1. Please click on "gear" icon near "Build" task in ``Menu > Tasks``
-2. Replace template in ``tasks.json`` with this code
+1. The menu item ``Terminal > Run Task...`` opens up a list of VSCode
+   tasks for PlatformIO. In the line ``PlatformIO: Build``, press the
+   gear icon on the far right side of the list. This creates or opens
+   the file ``.vscode/tasks.json`` with some template code.
+
+2. Replace the template in ``tasks.json`` with this code
 
   .. code-block:: json
 
@@ -218,15 +222,15 @@ command:
         ]
     }
 
-See more options in `official VSCode documentation <https://code.visualstudio.com/docs/editor/tasks#_output-behavior>`__.
+See more options in the `official VSCode documentation <https://code.visualstudio.com/docs/editor/tasks#_output-behavior>`__.
 
 .. _ide_vscode_custom_task:
 
 Custom Tasks
 ~~~~~~~~~~~~
 
-Custom tasks can be added to ``tasks.json`` file located in ``.vscode`` folder
-in the root of project. Please read official documentation `Tasks in VSCode <https://code.visualstudio.com/docs/editor/tasks#vscode>`_.
+Custom tasks can be added to ``tasks.json`` file located in the ``.vscode`` folder
+in the root of project. Please read the official documentation `Tasks in VSCode <https://code.visualstudio.com/docs/editor/tasks#vscode>`_.
 
 This simple example demonstrates a custom monitor task which echoes input locally.
 There are a lot of other commands, please read more about :ref:`piocore` and
@@ -253,9 +257,9 @@ its commands (:ref:`userguide`).
         ]
     }
 
-If ``platformio`` executable file is not in your system environment "PATH", you
-can provide a full path to binary folder using ``options`` field for task. For example,
-``platformio`` binary is located in home folder "~/.platformio/penv/bin":
+If the ``platformio`` executable file is not in your system environment "PATH", you
+can provide the full path to the binary folder using the ``options`` field for the task. For example,
+if the ``platformio`` binary is located in the home folder "~/.platformio/penv/bin":
 
 .. code-block:: json
 
@@ -286,7 +290,7 @@ Multi-project Workspaces
 
 You can work with multiple project folders in Visual Studio Code with
 multi-root workspaces. This can be very helpful when you are working on
-several related projects at one time. Read more in documentation
+several related projects at the same time. Read more in the documentation
 `Multi-root Workspaces <https://code.visualstudio.com/docs/editor/multi-root-workspaces>`_.
 
 Serial Port Monitor
@@ -322,8 +326,8 @@ Debugging
 Debugging in VSCode works in combination with :ref:`piodebug`. You should
 have :ref:`pioaccount` to work with it.
 
-VSCode has a separate activity view named "Debug" (bug icon on the left toolbar).
-:ref:`piodebug` extends it with the next advanced debugging instruments and features:
+VSCode has a separate activity view named "Debug" (accessed by the bug icon on the left toolbar).
+:ref:`piodebug` extends it with more advanced debugging instruments and features:
 
 - Local, Global, and Static Variable Explorer
 - Conditional Breakpoints
@@ -335,39 +339,40 @@ VSCode has a separate activity view named "Debug" (bug icon on the left toolbar)
 - Multi-thread support
 - A hot restart of an active debugging session.
 
-There are 2 pre-configured debugging configurations:
+There are two pre-configured debugging configurations:
 
 :PIO Debug:
-  **Default configuration**. PlatformIO runs **Pre-Debug** task and builds
-  project using :ref:`Debug Configuration <build_configurations>`. Also, it
+  **Default configuration**. PlatformIO runs the **Pre-Debug** task and builds
+  the project using :ref:`Debug Configuration <build_configurations>`. Also, it
   checks for project changes.
 
 :PIO Debug (skip Pre-Debug):
-  PlatformIO skips **Pre-Debug** stage and DOES NOT build or check project changes.
+  PlatformIO skips the **Pre-Debug** stage and DOES NOT build or check the project for changes.
   If you do changes in project source files, they will not be reflected in
-  a debug session until you switch back to "PIO Debug" configuration or
-  manually run "Pre-Debug" task.
+  debug sessions until you switch back to the "PIO Debug" configuration or
+  manually run the "Pre-Debug" task.
 
   This configuration is very useful for quick debug session. It is super fast
-  and skips different checks. You manually control project changes.
+  by skipping several checks, letting you control project changes manually.
 
 .. note::
   Please note that :ref:`piodebug` will use the first declared build
-  environment in :ref:`projectconf` if :ref:`projectconf_pio_default_envs` option
-  is not specified.
+  environment in :ref:`projectconf` if the :ref:`projectconf_pio_default_envs`
+  option is not specified.
 
 .. image:: ../_static/images/ide/vscode/platformio-ide-vscode-debug.png
 
 Variable Format
 ~~~~~~~~~~~~~~~
 
-Currently, VSCode does not provide UI/API to change variable format. See
+Currently, VSCode does not provide an UI or API to change the variable format. See the
 related `VSCode Issue #28025 <https://github.com/Microsoft/vscode/issues/28025>`_.
 
-Temporary solution is to set the default numeric base in which the debugger
-displays numeric output using Debug Console (you will see it during active
-debugging session). For example, show variables in hexadecimal format (copy
-below and paste into "Debug Console"):
+A temporary solution is to set the default numerical base in which the
+debugger displays numeric output in the Debug Console. (The Debug
+Console is visible during active debugging sessions). For example, to
+show variables in hexadecimal format, copy the code below and paste it
+into "Debug Console":
 
 .. code::
 
@@ -379,10 +384,10 @@ Watchpoints
 ~~~~~~~~~~~
 
 Please read `GDB: Setting Watchpoints <https://sourceware.org/gdb/download/onlinedocs/gdb/Set-Watchpoints.html>`__
-before.
+first.
 
-Currently, VSCode does not provide an API to change value format of watch points.
-You can manually cast output setting it as a watch of a pointer:
+Currently, VSCode does not provide an API to change the value format of watchpoints.
+You can manually cast watchpoint expressions to display the value as specific pointer types:
 
 * ``$pc``, default decimal integer format
 * ``*0x10012000``, an address, default decimal integer format
@@ -392,15 +397,15 @@ You can manually cast output setting it as a watch of a pointer:
 Install Shell Commands
 ----------------------
 
-Please navigate to PIO Core :ref:`piocore_install_shell_commands`.
+Please refer to PIO Core :ref:`piocore_install_shell_commands`.
 
 Proxy Server Support
 --------------------
 
-There 2 options how to configure a proxy server:
+There are two options how to configure a proxy server:
 
-1. Declare ``HTTP_PROXY`` and ``HTTPS_PROXY`` system environment variables (
-   ``HTTP_PROXY=http://user:pass@10.10.1.10:3128/``, etc.)
+1. Declare the ``HTTP_PROXY`` and ``HTTPS_PROXY`` system environment variables
+   (for example ``HTTP_PROXY=http://user:pass@10.10.1.10:3128/``, etc.)
 2. Open `VSCode Settings <https://code.visualstudio.com/docs/getstarted/settings>`__
    and search for "Proxy". Please set "Http: Proxy" and disable
    "Http: Proxy Strict SSL".
@@ -414,59 +419,56 @@ Settings
 
 ``platformio-ide.activateOnlyOnPlatformIOProject``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Activate extension only when PlatformIO-based project (with :ref:`projectconf`)
-is opened in workspace, default value is ``false``.
+If true, activate the ``platformio ide`` extension only when a
+PlatformIO-based project (that has a :ref:`projectconf`) is open in the
+workspace. The default value is ``false``.
 
 ``platformio-ide.autoCloseSerialMonitor``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Automatically close :ref:`cmd_device_monitor` before uploading/testing,
-default value is ``true``.
+If true, automatically close :ref:`cmd_device_monitor` before uploading/testing.
+The default value is ``true``.
 
 ``platformio-ide.autoRebuildAutocompleteIndex``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Automatically rebuild C/C++ Project Index when :ref:`projectconf` is changed
-or when new libraries are installed, default value is ``true``.
+If true, automatically rebuild the C/C++ Project Index when :ref:`projectconf`
+is changed or when new libraries are installed. The default value is ``true``.
 
 ``platformio-ide.buildTask``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-A build task (label) which is used by "Build" button in the
-:ref:`ide_vscode_toolbar` and :ref:`ide_vscode_keybindings`. Default is set to
-``PlatformIO: Build``.
+The build task (label) that is launched by the "Build" button in the
+:ref:`ide_vscode_toolbar` and :ref:`ide_vscode_keybindings`. The default is ``PlatformIO: Build``.
 
-You can create custom :ref:`ide_vscode_custom_task` and assign to ``platformio-ide.buildTask``.
+You can create custom :ref:`ide_vscode_custom_task` and assign one of them to ``platformio-ide.buildTask``.
 
 ``platformio-ide.customPATH``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Custom PATH for ``platformio`` command. Paste here the result of ``echo $PATH``
+Custom PATH for the ``platformio`` command. Paste here the result of ``echo $PATH``
 (Unix) / ``echo %PATH%`` (Windows) command by typing into your system terminal
-if you prefer to use custom version of :ref:`piocore`, default value is ``null``.
+if you prefer to use a custom version of :ref:`piocore`. The default value is ``null``, meaning PlatformIO looks for the ``platformio`` command in the system path.
 
 ``platformio-ide.forceUploadAndMonitor``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Force "Upload and Monitor" task for Upload (``platformio-ide.upload``) command,
-default value is ``false``.
+If true, the Upload (``platformio-ide.upload``) command is changed to
+use the "Upload and Monitor" task. The default value is ``false``.
 
 ``platformio-ide.reopenSerialMonitorDelay``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Configure time in milliseconds after which reopen Serial Port Monitor,
-default value is ``0``, which means reopen instantly.
+Configure the time in milliseconds before reopening the Serial Port Monitor.
+The default value is ``0``, which means to reopen instantly.
 
 ``platformio-ide.updateTerminalPathConfiguration``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Update Terminal configuration with patched PATH environment, default value
-is ``true``.
+If true, use a patched PATH environment for the Terminal
+configuration. The default value is ``true``.
 
 ``platformio-ide.useBuiltinPIOCore``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Use built-in :ref:`piocore`, default value is ``true``.
+If true, use the built-in :ref:`piocore`. The default value is ``true``.
 
 ``platformio-ide.useDevelopmentPIOCore``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Use development version of :ref:`piocore`, default value is ``false``.
+If true, use the development version of :ref:`piocore`. The default
+value is ``false``.
 
 Known issues
 ------------
@@ -480,10 +482,9 @@ This is a known bug in VSCode Terminal
 A temporary solution is to install packages using a system terminal (not VSCode Terminal).
 Please use "Solution 3: Run from Terminal" in FAQ > Package Manager >
 :ref:`faq_package_manager_error_5`.
-
-Now, back to VSCode.
+Afterwards, go back to using the VSCode Terminal.
 
 Changelog
 ---------
 
-Please visit `releases page <https://github.com/platformio/platformio-vscode-ide/releases>`_.
+Please visit the `releases page <https://github.com/platformio/platformio-vscode-ide/releases>`_.

--- a/librarymanager/ldf.rst
+++ b/librarymanager/ldf.rst
@@ -16,12 +16,12 @@ Library Dependency Finder (LDF)
 
 Library Dependency Finder is a core part of PlatformIO Build System that
 operates with the C/C++ source files and looks for ``#include ...``
-directives.
+directives to know what header directories to include for the compiler.
 
 In spite of the fact that Library Dependency Finder is written in pure Python,
 it evaluates :ref:`ldf_c_cond_syntax` (``#ifdef``, ``if``, ``defined``,
 ``else``, and ``elif``) without calling ``gcc -E``. This approach allows
-significantly reduce total compilation time. See :ref:`ldf_mode` for more
+to significantly reduce the total compilation time. See :ref:`ldf_mode` for more
 details.
 
 .. contents::
@@ -88,8 +88,8 @@ The mode can be changed using :ref:`projectconf_lib_ldf_mode` option in
 
 .. note::
   Usually, when the LDF appears to fail to identify a dependency of a library,
-  it is because the dependency is only referenced from the library source file,
-  and not the library header file (see example below). In this case, it is
+  it is because the dependency is only referenced from a library source file,
+  and not a library header file (see example below). In this case, it is
   necessary to either explicitly reference the dependency from the project
   source or :ref:`projectconf` (:ref:`projectconf_lib_deps` option), or change
   the LDF mode to "deep" (not generally recommended).
@@ -97,13 +97,13 @@ The mode can be changed using :ref:`projectconf_lib_ldf_mode` option in
 A difference between ``chain/chain+`` and ``deep/deep+`` modes. For example,
 there are 2 libraries:
 
-* Library "Foo" with files:
+* Library ``Foo`` with files:
 
   - ``Foo/foo.h``
   - ``Foo/foo.cpp``
   - ``Foo/extra.cpp``
 
-* Library "Bar" with files:
+* Library ``Bar`` with files:
 
   - ``Bar/bar.h``
   - ``Bar/bar.cpp``
@@ -111,31 +111,32 @@ there are 2 libraries:
 :Case 1:
 
     * ``lib_ldf_mode = chain``
-    * ``Foo/foo.h`` depends on "Bar" library (contains ``#include <bar.h>``)
+    * ``Foo/foo.h`` depends on the ``Bar`` library (contains ``#include <bar.h>``)
     * ``#include <foo.h>`` is located in one of the project source files
 
-    Here are nested includes (``project file > foo.h > bar.h``) and ``LDF``
-    will find both libraries "Foo" and "Bar".
+    Here the nested includes (``project file > foo.h > bar.h``) and LDF
+    will find both libraries "Foo`` and ``Bar``.
 
 :Case 2:
 
     * ``lib_ldf_mode = chain``
-    * ``Foo/extra.cpp`` depends on "Bar" library (contains ``#include <bar.h>``)
+    * ``Foo/extra.cpp`` depends on the ``Bar`` library (contains ``#include <bar.h>``)
     * ``#include <foo.h>`` is located in one of the project source files
 
-    In this case, ``LDF`` will not find "Bar" library because it doesn't know
-    about CPP file (``Foo/extra.cpp``).
+    In this case, LDF will not find the ``Bar`` library because it doesn't know
+    about the CPP file (``Foo/extra.cpp``).
 
 :Case 3:
 
     * ``lib_ldf_mode = deep``
-    * ``Foo/extra.cpp`` depends on "Bar" library (contains ``#include <bar.h>``)
+    * ``Foo/extra.cpp`` depends on ``Bar`` library (contains ``#include <bar.h>``)
     * ``#include <foo.h>`` is located in one of the project source files
 
-    Firstly, ``LDF`` finds "Foo" library, then it parses all sources from "Foo"
-    library and finds ``Foo/extra.cpp`` that depends on ``#include <bar.h>``.
-    Secondly, it will parse all sources from "Bar" library and this operation
-    continues until all dependencies will not be parsed.
+    Firstly, LDF finds the ``Foo`` library, then it parses all sources
+    from the ``Foo`` library and finds ``Foo/extra.cpp`` that depends
+    on ``#include <bar.h>``.  Secondly, it will parse all sources from
+    the ``Bar`` library. This operation continues until all
+    dependencies will not be parsed.
 
 .. _ldf_compat_mode:
 

--- a/platforms/creating_board.rst
+++ b/platforms/creating_board.rst
@@ -11,32 +11,32 @@
 
 .. _board_creating:
 
-Custom Embedded Board
-=====================
+Custom Embedded Boards
+======================
 
-*PlatformIO* has pre-built settings for the most popular embedded boards. This
-list is available:
+*PlatformIO* has pre-built settings for many popular embedded
+boards. The list of these boards is available as a web page at
+`PlatformIO Boards Explorer <https://platformio.org/boards>`_ or
+through the CLI command :ref:`cmd_boards`.
 
-* `Embedded Boards Explorer <https://platformio.org/boards>`_ (Web)
-* :ref:`cmd_boards` (CLI command)
-
-Nevertheless, PlatformIO allows one to create own board or override existing
-board's settings. All data is declared using
-`JSON-style <http://en.wikipedia.org/wiki/JSON>`_ via
-`associative array <http://en.wikipedia.org/wiki/Associative_array>`_
-(name/value pairs).
+Custom boards can also be defined from scratch or by overriding settings
+of existing boards. All data is declared using the `JSON syntax
+<http://en.wikipedia.org/wiki/JSON>`_ via `associative array
+<http://en.wikipedia.org/wiki/Associative_array>`_ name/value pairs.
 
 .. contents::
 
 JSON Structure
 --------------
 
-The key fields:
+The key fields are:
 
-* ``build`` data will be used by :ref:`platforms` and :ref:`frameworks` builders
-* ``frameworks`` is the list with supported :ref:`frameworks`
+* ``build`` data is handed over to the :ref:`platforms` and :ref:`frameworks` builders
+* ``frameworks`` is the list with supported :ref:`frameworks`. Each working environment for each project that uses the board will choose one of the frameworks declared here.
 * ``platform`` name of :ref:`platforms`
 * ``upload`` upload settings which depend on the ``platform``
+
+For details, see existing boards as examples, available under ``.platformio/platforms/*/boards/``.
 
 .. code-block:: json
 

--- a/platforms/creating_platform.rst
+++ b/platforms/creating_platform.rst
@@ -11,19 +11,20 @@
 
 .. _platform_creating:
 
-Custom Development Platform
-===========================
+Custom Development Platforms
+============================
 
-*PlatformIO* was developed like a tool that may build the same source code
-for the different development platforms via single command :ref:`cmd_run`
+*PlatformIO* can build the same binary code under
+different host systems via the single command :ref:`cmd_run`
 without any dependent software or requirements.
 
-For this purpose *PlatformIO* uses own pre-configured platforms data:
-build scripts, toolchains, the settings for the most popular embedded
-boards and etc. These data are pre-built and packaged to the different
-``packages``. It allows *PlatformIO* to have multiple development platforms
-which can use the same packages(toolchains, frameworks), but have
-different/own build scripts, uploader and etc.
+A *manifest* describes how to produce binaries for a particular
+platform under one or multiple host systems by a set of build scripts,
+toolchains, the settings for the most popular embedded boards, etc.
+
+This guide explains how to write manifests, to support building for
+new development platforms.
+
 
 **Step-by-Step Manual**
 
@@ -39,20 +40,37 @@ different/own build scripts, uploader and etc.
 Packages
 --------
 
-PlatformIO has own registry with pre-built packages for the most popular
-operating systems and you can use them in your manifest. These packages are
-stored in super-fast and reliably CDN storage provided by JFrog Bintray:
+Some tools are the same when compiling for several platforms, for
+example a common compiler. A *package* is some tool or framework that
+can be used when compiling for one or multiple platforms. Even if
+multiple platforms use the same package, the package only needs to be
+downloaded once. Since each package is pre-built for the different
+host systems (Windows, Mac, Linux), developers can get started without
+first compiling the tools.
 
-- https://bintray.com/platformio/dl-packages
+PlatformIO has a registry with pre-built packages for the most popular
+operating systems and you can use them in your platform
+manifest. These packages are stored in the super-fast and reliably CDN
+storage provided by `JFrog Bintray
+<https://bintray.com/platformio/dl-packages>`_.
+
+Each platform definition must define ``packageRepositories`` to link
+to *package manifest files* that lists how PlatformIO can download the
+used packages. To use the pre-built packages, include
+http://dl.platformio.org/packages/manifest.json in the
+``packageRepositories`` list. Platform definitions can also use custom
+packages.
 
 .. _platform_creating_manifest_file:
 
 Manifest File ``platform.json``
 -------------------------------
 
-See example with a manifest for packages:
+Eack platform definition includes a *manifest file* with a particular
+format that is parsed by PlatformIO when handling projects using that
+platform.
 
-- http://dl.platformio.org/packages/manifest.json
+Here is an example ``platform.json`` for the fictitious platform "myplatform":
 
 .. code-block:: json
 
@@ -140,10 +158,12 @@ See example with a manifest for packages:
 Build Script ``main.py``
 ------------------------
 
-Platform's build script is based on a next-generation build tool named
-`SCons <http://www.scons.org>`_. PlatformIO has own built-in firmware builder
-``env.BuildProgram`` with the deep libraries search. Please look into a
-base template of ``main.py``.
+Each platform definition must include a ``main.py``.
+
+PlatformIO's build script is based on a next-generation build tool
+named `SCons <http://www.scons.org>`_. PlatformIO has its own built-in
+firmware builder ``env.BuildProgram`` with deep library search. Please
+see the following template as start for developing your own ``main.py``.
 
 .. code-block:: python
 
@@ -226,15 +246,17 @@ base template of ``main.py``.
 Installation
 ------------
 
-1. Create ``platforms`` directory in :ref:`projectconf_pio_core_dir` if it
-   doesn't exist.
-2. Create ``myplatform`` directory in ``platforms``
-3. Copy ``platform.json`` and ``builder/main.py`` files to ``myplatform`` directory.
-4. Search available platforms via :ref:`cmd_platform_search` command. You
-   should see ``myplatform`` platform.
-5. Install ``myplatform`` platform via :ref:`cmd_platform_install` command.
+Using the "myplatform" platform example above:
 
-Now, you can use ``myplatform`` for the :ref:`projectconf_env_platform`
+1. Create a ``platforms`` directory in :ref:`projectconf_pio_core_dir` if it
+   doesn't exist.
+2. Create a ``myplatform`` directory in ``platforms``
+3. Copy the ``platform.json`` and ``builder/main.py`` files to the ``myplatform`` directory.
+4. Search the available platforms via the :ref:`cmd_platform_search` command. You
+   should see the new ``myplatform`` platform.
+5. Install the ``myplatform`` platform via the :ref:`cmd_platform_install` command.
+
+Now, you can use ``myplatform`` as value for the :ref:`projectconf_env_platform`
 option in :ref:`projectconf`.
 
 Examples

--- a/platforms/index.rst
+++ b/platforms/index.rst
@@ -14,19 +14,34 @@
 Development Platforms
 =====================
 
-PlatformIO ecosystem has decentralized architecture. Build scripts, toolchains,
-the pre-built tools for the popular OS (*Mac OS X, Linux (+ARM) and Windows*)
-are organized into the multiple development platforms.
+The PlatformIO ecosystem has a decentralized architecture, allowing
+development for a range of *development platforms*. A development
+platform (or just "platform" for short) is usually a particular
+microcontroller or processor architecture that PlatformIO projects can
+be compiled to run on. (A few platforms, for example Teensy, use
+different target architectures for different boards.)
 
-Each development platform contains:
+Each of the three supported host systems Mac OS X, Linux and Windows
+support compiling for all platforms listed below. Some platforms are
+also supported under ARM Linux hosts such as Raspberry Pi. For each
+development platform, PlatformIO defines:
 
-- **PlatformIO Build System** based build scripts for the supported frameworks
+- The **PlatformIO Build System** build scripts for the supported frameworks
   and SDKs
-- Pre-configured presets for embedded boards
-- Pre-compiled toolchains and relative tools for multiple architectures.
+- Pre-configured presets for embedded circuit boards
+- Pre-compiled toolchains and related tools for the architechture(s)
 
-A platform name or its specific version could could be specified using
-:ref:`projectconf_env_platform` option in :ref:`projectconf`.
+Each project must specify the platform name using the
+:ref:`projectconf_env_platform` option in :ref:`projectconf`. A
+specific platform version can optionally be specified as well. As
+embedded boards are equipped with a particular microcontroller, each
+embedded board specifies what development platform it uses and this
+can not be changed.
+
+If a new board uses an architecture not in this list, a custom
+development platform can be created; see `Custom Development Platforms
+<https://platformio.org/platforms/creating_platform.html>`_.
+
 
 Embedded
 --------

--- a/projectconf.rst
+++ b/projectconf.rst
@@ -14,27 +14,26 @@
 "platformio.ini" (Project Configuration File)
 =============================================
 
-The Project configuration file is named ``platformio.ini``. This is a
+Each PlatformIO project has a configuration file named
+``platformio.ini`` in the root directory for the project. This is a
 `INI-style <http://en.wikipedia.org/wiki/INI_file>`_ file.
 
-``platformio.ini`` has sections (each denoted by a ``[header]``) and
+``platformio.ini`` has sections (each denoted by a ``[``header``]``) and
 key / value pairs within the sections. Lines beginning with ``;``
 are ignored and may be used to provide comments.
 
-Multiple values option can be specified in 2 ways:
+Multiple value options can be specified in two ways:
 
 1. Split values with ", " (comma + space)
-2. Use multi-line format, where each new line should start with 2 spaces
-   (minimum)
+2. Multi-line format, where each new line starts with at least two spaces
 
-There are 2 system reserved sections:
+There are two required sections:
 
 * :ref:`piocore` settings: :ref:`projectconf_section_platformio`
 * Environment settings: :ref:`projectconf_section_env`
 
-The other sections can be used by users, for example, for
-:ref:`projectconf_dynamic_vars`. The sections and their allowable values are
-described below.
+The other sections are optional to include. Here are the allowed
+sections and their allowed contents:
 
 .. toctree::
     :maxdepth: 2
@@ -43,9 +42,10 @@ described below.
     projectconf/section_env
     projectconf/build_configurations
     projectconf/dynamic_variables
-    projectconf/examples
 
 **Example**
+
+For more examples, see :ref:`projectconf/examples`.
 
 .. code-block:: ini
 

--- a/projectconf/advanced_scripting.rst
+++ b/projectconf/advanced_scripting.rst
@@ -16,53 +16,53 @@ Advanced Scripting
 
 .. warning::
 
-  Advanced Scripting is recommended for Advanced Users and requires Python
-  language knowledge.
+  Advanced Scripting is recommended for Advanced Users and requires
+  knowledge of the Python language.
 
-  We highly recommend to take a look at :ref:`projectconf_dynamic_build_flags`
-  option where you can use any programming language. Also, this option is
-  useful if you need to apply changes to the project before building/uploading
-  process:
+.. warning::
+
+  :ref:`projectconf_dynamic_build_flags` is a highly recommended
+  alternative to advanced scripting, where you can use any programming
+  language. Also, that option is useful if you need to apply changes
+  to the project before the building/uploading process, such as:
 
   * Macro with the latest VCS revision/tag "on-the-fly"
   * Generate dynamic headers (``*.h``)
   * Process media content before generating SPIFFS image
   * Make some changes to source code or related libraries
 
-  More details :ref:`projectconf_dynamic_build_flags`.
-
 .. contents::
 
-PlatformIO Build System allows one to extend build process with the custom
-:ref:`projectconf_extra_scripts` using Python interpreter and
-`SCons <http://www.scons.org>`_ construction tool.
-Build and upload flags, targets, toolchains data, and other information are
-stored in `SCons Construction Environments <http://www.scons.org/doc/production/HTML/scons-user.html#chap-environments>`_.
+The PlatformIO Build System allows the user to extend the build process with
+custom scripts using the Python interpreter and
+the `SCons <http://www.scons.org>`_ construction tool.
+Build flags, upload flags, targets, toolchains data and other information are
+available for modification as `SCons Construction Environments <http://www.scons.org/doc/production/HTML/scons-user.html#chap-environments>`_.
+Custom scripts are included with :ref:`projectconf_extra_scripts`
 
 .. warning::
-  You can not run/debug these scripts directly with Python interpreter. They
-  will be loaded automatically when you processing project environment using
-  :ref:`cmd_run` command.
+  You can not run or debug these scripts manually with a Python
+  interpreter. They will be loaded automatically when the
+  :ref:`cmd_run` command processes the project environment.
 
 Launch types
 ~~~~~~~~~~~~
 
-There are 2 launch type of extra scripts:
+There are two execution orders for extra scripts:
 
-1. **PRE** - executes before a main script of :ref:`platforms`
-2. **POST** - executes after a main script of :ref:`platforms`
-
+1. **PRE** - executes before the main script of :ref:`platforms`
+2. **POST** - executes after the main script of :ref:`platforms`
 
 Multiple extra scripts are allowed. Please split them via  ", "
 (comma + space) in the same line or use multi-line values.
 
-For example, :ref:`projectconf`
+For example, in :ref:`projectconf`:
 
 .. code-block:: ini
 
   [env:my_env_1]
   platform = ...
-  ; without prefix, POST script
+  ; Defaults to POST script since no prefix is used
   extra_scripts = post_extra_script.py
 
   [env:my_env_2]
@@ -72,20 +72,20 @@ For example, :ref:`projectconf`
     post:post_extra_script1.py
     post_extra_script2.py
 
-This option can also be set by global environment variable :envvar:`PLATFORMIO_EXTRA_SCRIPTS`.
+This option can also be set by the global environment variable :envvar:`PLATFORMIO_EXTRA_SCRIPTS`.
 
 Construction Environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are 2 built-in construction environments which PlatformIO Build System
-uses to process a project:
+The PlatformIO Build System uses two built-in construction environments
+to process each project:
 
-* ``env``, ``Import("env")`` - global construction environment which is used
-  for :ref:`platforms` and :ref:`frameworks` build scripts, upload tools,
+* ``env``, ``Import("env")`` - the global construction environment used
+  for the :ref:`platforms` and :ref:`frameworks` build scripts, upload tools,
   :ref:`ldf`, and other internal operations
-* ``projenv``, ``Import("projenv")`` - isolated construction environment which
-  is used for processing of a project source code located in :ref:`projectconf_pio_src_dir`.
-  Please note that :ref:`projectconf_src_build_flags` specified in
+* ``projenv``, ``Import("projenv")`` - the isolated construction environment
+  used for processing the project source code in :ref:`projectconf_pio_src_dir`.
+  Please note that any :ref:`projectconf_src_build_flags` specified in
   :ref:`projectconf` will be passed to ``projenv`` and not to ``env``.
 
 
@@ -154,18 +154,18 @@ data or add new.
 Before/Pre and After/Post actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PlatformIO Build System has a rich API that allows one to attach different pre-/post
+The PlatformIO Build System has a rich API that allows one to attach different pre-/post
 actions (hooks) using ``env.AddPreAction(target, callback)`` or
-``env.AddPreAction(target, [callback1, callback2, ...])`` function. A first
-argument ``target`` can be a name of target that is passed using
-:option:`platformio run --target` command, a name of built-in targets
-(buildprog, size, upload, program, buildfs, uploadfs, uploadfsota) or path
-to file which PlatformIO processes (ELF, HEX, BIN, OBJ, etc.).
+``env.AddPreAction(target, [callback1, callback2, ...])`` function. The first
+argument ``target`` can be the name of a target that is passed using the
+:option:`platformio run --target` command, the name of a built-in target
+(buildprog, size, upload, program, buildfs, uploadfs, uploadfsota) or the path
+to a file which PlatformIO processes (ELF, HEX, BIN, OBJ, etc.).
 
 
 **Examples**
 
-``extra_script.py`` file is located on the same level as ``platformio.ini``.
+The ``extra_script.py`` file is located in the same directory as ``platformio.ini``.
 
 ``platformio.ini``:
 

--- a/projectconf/build_configurations.rst
+++ b/projectconf/build_configurations.rst
@@ -34,15 +34,16 @@ If you need to build a project in ``debug`` configuration, please use one of
 these options:
 
 * Add :ref:`projectconf_build_type` with ``debug`` value to :ref:`projectconf`
-* Use target ``debug`` for :option:`platformio run --target` command.
+* Use target ``debug`` for the :option:`platformio run --target` command.
 
 .. note::
   :ref:`piodebug` automatically switches to ``debug`` configuration when you do
-  project debugging from :ref:`pioide` or use :ref:`cmd_debug` command.
+  project debugging from :ref:`pioide` or use the :ref:`cmd_debug` command.
 
-  To avoid project rebuilding, please create a separate build environment
-  and add ``build_type = debug``. See example below where ``mydebug`` build
-  environment will be used automatically by :ref:`piodebug`:
+  To avoid having :ref:`piodebug` rebuild the project, please create a
+  separate build environment that defines ``build_type = debug``. See
+  the example below where the ``mydebug`` build environment will be used
+  automatically by :ref:`piodebug`:
 
   .. code-block:: ini
 
@@ -59,5 +60,5 @@ these options:
      build_type = debug
      some_extra_options = ...
 
-Please note that you can set a default build environment per a project using
+Please note that you can set a default build environment per a project using the
 :ref:`projectconf_pio_default_envs` option in :ref:`projectconf_section_platformio`.

--- a/projectconf/section_env.rst
+++ b/projectconf/section_env.rst
@@ -17,18 +17,23 @@ Section ``[env]``
 .. contents::
     :local:
 
-Allows declaring configuration environments for building, programming, debugging,
-unit testing, device monitoring, library dependencies, etc.
+Each project may have multiple *configuration environments* defining
+the available project tasks for building, programming, debugging, unit
+testing, device monitoring, library dependencies, etc. The
+configuration environments are declared using ``[env]`` sections in
+:ref:`projectconf`.
+
+The allowed options are listed under `Options`_.
 
 Common ``[env]``
 ----------------
 
 .. versionadded:: 4.0
 
-Allows declaring a configuration environment with common options that will be shared
-between all ``[env:NAME]`` environments in :ref:`projectconf`. It is very useful if
-the configuration file has a lot of custom environments ``[env:NAME]`` and they have
-common data.
+An optional configuration environment with common options that will be
+shared between all ``[env:NAME]`` environments in the platform.ini
+file. It is very useful if the configuration file has a lot of
+environments ``[env:NAME]`` and they share common settings.
 
 For example:
 
@@ -51,8 +56,8 @@ For example:
     build_flags = -D DEBUG
     lib_deps = DepCustom
 
-In this example we have 2 configuration environments ``release`` and ``debug``. This
-is the same if you duplicate all options:
+In this example we have two configuration environments ``release`` and ``debug``. This
+is equivalent to duplicating all options as shown below:
 
 .. code-block:: ini
 
@@ -75,18 +80,17 @@ is the same if you duplicate all options:
 Environment ``[env:NAME]``
 --------------------------
 
-A section with ``env:`` prefix is used to define **a working environment** for
-:ref:`cmd_run`, :ref:`cmd_test`, :ref:`cmd_check`, :ref:`cmd_debug`, and other commands.
-Project should contain as minimum one working environment.
+A section with an ``env:`` prefix defines a **working environment** for
+:ref:`cmd_run`, :ref:`cmd_test`, :ref:`cmd_check`, :ref:`cmd_debug` and other commands.
+Multiple ``[env:NAME]`` environments with different ``NAME`` are allowed. Every project must define at least one working environment.
 
 Each environment must have a unique ``NAME``. The valid chars for ``NAME`` are
 letters ``a-z``, numbers ``0-9``,  special char ``_`` (underscore).
 For example, ``[env:hello_world]``.
-Multiple ``[env:NAME]`` environments with different ``NAME`` are allowed.
 
-If you have more than one working environment and you need to process only a few
-of them, please check ``-e, --environment`` option for commands mentioned above
-or :ref:`projectconf_pio_default_envs` option.
+If you have multiple working environments and you need to process only a few
+of them, the commands mentioned above accept the ``-e, --environment`` option to select a subset of the working environments to process.
+The [platformio] :ref:`projectconf_pio_default_envs` option can be used to define a default set of working environments for the commands to process.
 
 Options
 -------

--- a/projectconf/section_env_build.rst
+++ b/projectconf/section_env_build.rst
@@ -35,14 +35,17 @@ See extended documentation for :ref:`build_configurations`.
 
 Type: ``String`` | Multiple: ``Yes``
 
-These flags/options control preprocessing, compilation, assembly and linking
-processes:
+These flags/options affect the preprocessing, compilation, assembly
+and linking processes for C and C++ code. All compiler and linker
+flags can be used. Here is a list of some common options.
+
+In spite of the name, ``CPPDEFINES`` rows also applies to the C compiler.
 
 .. list-table::
     :header-rows:  1
 
     * - Format
-      - Scope
+      - Affects build variable
       - Description
     * - ``-D name``
       - CPPDEFINES
@@ -61,10 +64,10 @@ processes:
         preprocessor
     * - ``-Wall``
       - CCFLAGS
-      - Turns on all optional warnings which are desirable for normal code.
+      - Turn on all optional warnings which are desirable for normal code.
     * - ``-Werror``
       - CCFLAGS
-      - Make all warnings into hard errors. Source code which triggers warnings will be rejected.
+      - Make all warnings into hard errors. With this option, if any source code triggers warnings, the compilation will be aborted.
     * - ``-w``
       - CCFLAGS
       - Suppress all warnings, including those which GNU CPP issues by default.
@@ -146,7 +149,7 @@ Examples:
 Built-in Variables
 ''''''''''''''''''
 
-You can inject into build flags built-in variables, such as:
+You can inject the built-in variables into your build flags, such as:
 
 * ``$PYTHONEXE``, full path to current Python interpreter
 * ``$UNIX_TIME``, current time in Unix format
@@ -157,26 +160,28 @@ You can inject into build flags built-in variables, such as:
 * ``$PROJECT_CORE_DIR``, PlatformIO Core directory, see :ref:`projectconf_pio_core_dir`
 * ``$PROJECT_BUILD_DIR``, project build directory per all environments
 * ``$BUILD_DIR``, build directory per current environment
-* `Need more PlatformIO variables? <https://github.com/platformio/platformio-core/blob/develop/platformio/builder/main.py#L99:L120>`_
 
-Please use target ``envdump`` for :option:`platformio run --target` command to
-see ALL variables from a build environment.
+See the `full list of PlatformIO variables <https://github.com/platformio/platformio-core/blob/develop/platformio/builder/main.py#L99:L120>`_.
+
+Please use target ``envdump`` for the :option:`platformio run --target`
+command to see ALL variable values for a build environment.
 
 .. _projectconf_dynamic_build_flags:
 
 Dynamic build flags
 '''''''''''''''''''
 
-PlatformIO allows one to run external command/script which outputs build flags
-into STDOUT. PlatformIO will automatically parse this output and append flags
-to a build environment.
+PlatformIO allows users to run an external command/script which
+outputs build flags into STDOUT by prepending the shell command with a
+``!`` character. PlatformIO will automatically replace commands with
+their output when appending flags to build environments.
 
 **You can use any shell or programming language.**
 
 This external command will be called on each :ref:`cmd_run` command before
 building/uploading process.
 
-Use Cases:
+Use cases:
 
  * Macro with the latest VCS revision/tag "on-the-fly"
  * Generate dynamic headers (``*.h``)
@@ -185,7 +190,7 @@ Use Cases:
 
 .. note::
   If you need more advanced control and would like to apply changes to
-  PlatformIO Build System environment, please refer to :ref:`projectconf_advanced_scripting`.
+  a PlatformIO Build System environment, please refer to :ref:`projectconf_advanced_scripting`.
 
 Example:
 
@@ -198,10 +203,10 @@ Example:
     build_flags = !echo "-DSOME_MACRO="$(some_cmd arg1 --option1)
 
 
-**Use Case: Create "PIO_SRC_REV" macro with the latest Git revision**
+**Use Case: Create a "PIO_SRC_REV" macro with the latest Git revision**
 
-You will need to create a separate file named ``git_rev_macro.py`` and place it
-near ``platformio.ini``.
+This example includes a separate file named ``git_rev_macro.py``, to be placed
+in the same directory as ``platformio.ini``.
 
 ``platformio.ini``:
 
@@ -227,11 +232,11 @@ near ``platformio.ini``.
 
 Type: ``String`` | Multiple: ``Yes``
 
-An option ``src_build_flags`` has the same behavior like ``build_flags``
-but will be applied only for the project source code from
+An option ``src_build_flags`` has the same behavior as ``build_flags``
+but will be applied only for project source files in the
 :ref:`projectconf_pio_src_dir` directory.
 
-This option can also be set by global environment variable
+This option can also be set by the global environment variable
 :envvar:`PLATFORMIO_SRC_BUILD_FLAGS`.
 
 .. _projectconf_build_unflags:
@@ -241,7 +246,7 @@ This option can also be set by global environment variable
 
 Type: ``String`` | Multiple: ``Yes``
 
-Remove base/initial flags which were set by development platform.
+Selectively remove base/initial flags that were set by the development platform.
 
 .. code-block:: ini
 
@@ -257,22 +262,22 @@ Remove base/initial flags which were set by development platform.
 Type: ``String (Templates)`` | Multiple: ``Yes``
 
 This option allows one to specify which source files should be
-included/excluded from :ref:`projectconf_pio_src_dir` for a build process.
-Filter supports 2 templates:
+included or excluded from :ref:`projectconf_pio_src_dir` for a build process.
+Filter supports two templates:
 
 * ``+<PATH>`` include template
 * ``-<PATH>`` exclude template
 
-``PATH`` MUST BE related from :ref:`projectconf_pio_src_dir`. All patterns will
-be applied in theirs order.
+``PATH`` is relative to :ref:`projectconf_pio_src_dir`. All patterns will
+be applied in their order of definition.
 `GLOB Patterns <http://en.wikipedia.org/wiki/Glob_(programming)>`_ are allowed.
 
 By default, ``src_filter`` is predefined to
 ``+<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/>``,
-that means "includes ALL files, then
-exclude ``.git`` and ``svn`` repository folders, ``example`` ... folder.
+meaning "include ALL files, then
+exclude the ``.git`` and ``svn`` repository folders and the ``example`` ... folder.
 
-This option can also be set by global environment variable
+This option can also be set by the global environment variable
 :envvar:`PLATFORMIO_SRC_FILTER`.
 
 .. _projectconf_targets:
@@ -282,16 +287,15 @@ This option can also be set by global environment variable
 
 Type: ``String`` | Multiple: ``Yes``
 
-A list of targets which will be processed by :ref:`cmd_run` command by
-default. You can enter more than one target, please split them with
-comma+space **", "**.
+A list of targets which will be processed by the :ref:`cmd_run` command by
+default. You can enter more than one target, if separated by comma+space **", "**.
 
 The list with available targets is located in :option:`platformio run --target`.
 
 **Examples**
 
 1. Build a project using :ref:`Release Configuration <build_configurations>`,
-   upload firmware, and start :ref:`Serial Monitor <cmd_device_monitor>`
+   upload the firmware, and start :ref:`Serial Monitor <cmd_device_monitor>`
    automatically:
 
     .. code-block:: ini

--- a/projectconf/section_platformio.rst
+++ b/projectconf/section_platformio.rst
@@ -17,8 +17,8 @@ Section ``[platformio]``
 .. contents::
     :local:
 
-A ``platformio`` section is used for overriding default configuration options
-for :ref:`piocore`.
+The platform.ini ``platformio`` section is used for overriding the
+default configuration options for :ref:`piocore`.
 
 .. note::
     Relative path is allowed for directory option:
@@ -27,14 +27,14 @@ for :ref:`piocore`.
     * ``../`` or ``..\`` go up to one folder
 
     There is a ``$PROJECT_HASH`` template variable. You can use it in a directory
-    path. It will by replaced by a SHA1[0:10] hash of a full project path.
+    path. It will by replaced by a SHA1[0:10] hash of the full project path.
     This is very useful to declare a global storage for project workspaces.
     For example, ``/tmp/pio-workspaces/$PROJECT_HASH`` (Unix) or
     ``$[sysenv.TEMP}/pio-workspaces/$PROJECT_HASH`` (Windows).
-    You can set a global workspace directory using system environment
+    You can set a global workspace directory using the system environment
     variable :envvar:`PLATFORMIO_WORKSPACE_DIR`.
 
-    See below available directory ``***_dir`` options.
+    See the available directory ``***_dir`` options below.
 
 Generic options
 ~~~~~~~~~~~~~~~
@@ -44,7 +44,7 @@ Generic options
 
 Type: ``String`` | Multiple: ``No``
 
-Describe a project with a short information. PlatformIO uses it for
+Short description of the project. PlatformIO uses it for
 :ref:`piohome` in the multiple places.
 
 .. _projectconf_pio_default_envs:
@@ -54,9 +54,9 @@ Describe a project with a short information. PlatformIO uses it for
 
 Type: ``String`` | Multiple: ``Yes``
 
-:ref:`cmd_run` command processes all environments ``[env:***]`` by default
-if :option:`platformio run --environment` option is not specified.
-:ref:`projectconf_pio_default_envs` allows one to define environments which
+The :ref:`cmd_run` command processes all environments ``[env:***]`` by default
+if the :option:`platformio run --environment` option is not specified.
+:ref:`projectconf_pio_default_envs` allows one to define which environments that
 should be processed by default.
 
 Also, :ref:`piodebug` checks this option when looking for debug environment.
@@ -223,12 +223,13 @@ Directory options
 
 Type: ``DirPath`` | Multiple: ``No``
 
-Is used to store development platform packages (toolchains, frameworks, SDKs,
-upload and debug tools), global libraries for :ref:`ldf`, and other PlatformIO
-Core service data. The size of this folder will depend on number of installed
-development platforms.
+The core_dir variable points out the directory used for all
+development platform packages (toolchains, frameworks, SDKs, upload
+and debug tools), global libraries for :ref:`ldf`, and other
+PlatformIO Core service data. The size of this folder will depend on
+the number of installed development platforms.
 
-A default value is User's home directory:
+The default value is the user's home directory:
 
 * Unix ``~/.platformio``
 * Windows ``%HOMEPATH%\.platformio``
@@ -357,14 +358,14 @@ a different configuration (new build flags, etc):
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``.pio``"
 
-A path to a project workspace directory where PlatformIO keeps by default
+The path to a project workspace directory where PlatformIO keeps by default
 compiled objects, static libraries, firmwares, and external library
-dependencies. It is used by the next options:
+dependencies. It is used by these options:
 
 - :ref:`projectconf_pio_build_dir`
 - :ref:`projectconf_pio_libdeps_dir`.
 
-A default value is ``.pio`` and means that folder is located in the root of
+The default value is ``.pio`` and means that folder is located in the root of
 project.
 
 This option can also be configured by the global environment variable
@@ -419,9 +420,10 @@ This option can also be configured by the global environment variable
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``include``"
 
-A path to project's default header files. PlatformIO uses it for :ref:`cmd_run`
-command. A default value is ``include`` that means that folder is located in the
-root of project. This path will be added to ``CPPPATH`` of build environment.
+The path to project's default header files. PlatformIO uses it for the
+:ref:`cmd_run` command. The default value is ``include`` meaning an
+``include`` directory located under the root directory of the project. This
+path will be added to ``CPPPATH`` of the build environment.
 
 If you need to add extra include directories to ``CPPPATH`` scope, please use
 :ref:`projectconf_build_flags` with ``-I /path/to/extra/dir`` option.
@@ -436,16 +438,16 @@ This option can also be configured by the global environment variable
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``src``"
 
-A path to project's source directory. PlatformIO uses it for :ref:`cmd_run`
-command. A default value is ``src`` that means that folder is located in the
-root of project.
+The path to the project's directory with source code. PlatformIO uses
+it for the :ref:`cmd_run` command. The default value is ``src``
+meaning a ``src`` directory located in the root directory of the project.
 
 This option can also be configured by the global environment variable
 :envvar:`PLATFORMIO_SRC_DIR`.
 
 .. note::
     This option is useful for people who migrate from Arduino IDE where
-    source directory should have the same name as a main source file.
+    the source directory should have the same name as the main source file.
     See `example <https://github.com/platformio/platform-atmelavr/tree/develop/examples/arduino-own-src_dir>`__ project with own source directory.
 
 .. _projectconf_pio_lib_dir:
@@ -455,18 +457,18 @@ This option can also be configured by the global environment variable
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``lib``"
 
-You can put here your own/private libraries. The source code of each library
+You can put your own/private libraries here. The source code of each library
 should be placed in separate directory, like
 ``lib/private_lib/[here are source files]``. This directory has the highest
 priority for :ref:`ldf`.
 
-A default value is ``lib`` that means that folder is located in the root of
-project.
+The default value is ``lib``, meaning a ``lib`` directory located in
+the root of the project.
 
 This option can also be configured by the global environment variable
 :envvar:`PLATFORMIO_LIB_DIR`.
 
-For example, see how can be organized ``Foo`` and ``Bar`` libraries:
+For example, see how the ``Foo`` and ``Bar`` libraries are organized:
 
 .. code::
 
@@ -492,10 +494,10 @@ Then in ``src/main.c`` you should use:
     #include <Foo.h>
     #include <Bar.h>
 
-    // rest H/C/CPP code
+    // rest of H/C/CPP code
 
-PlatformIO will find your libraries automatically, configure preprocessor's
-include paths and build them.
+PlatformIO will find your libraries automatically, configure the
+preprocessor's include paths and build them.
 
 .. _projectconf_pio_data_dir:
 
@@ -505,8 +507,8 @@ include paths and build them.
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``data``"
 
 Data directory to store contents and :ref:`platform_espressif_uploadfs`.
-A default value is ``data`` that means that folder is located in the root of
-project.
+The default value is ``data`` that means that folder is located in the root of
+the project.
 
 This option can also be configured by the global environment variable
 :envvar:`PLATFORMIO_DATA_DIR`.
@@ -518,9 +520,9 @@ This option can also be configured by the global environment variable
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``test``"
 
-Directory where :ref:`unit_testing` engine will look for the tests.
-A default value is ``test`` that means that folder is located in the root of
-project.
+The directory where :ref:`unit_testing` engine will look for the
+tests.  The default value is ``test``, meaning a ``test`` directory
+located in the root of the project.
 
 This option can also be configured by the global environment variable
 :envvar:`PLATFORMIO_TEST_DIR`.
@@ -532,13 +534,13 @@ This option can also be configured by the global environment variable
 
 Type: ``DirPath`` | Multiple: ``No`` | Default: "Project/``boards``"
 
-Custom board settings per project. You can change this path with your own.
-A default value is ``boards`` that means that folder is located in the root of
-project.
+The location of project-specific board definitions. Each project may
+choose a suitable directory name.  The default value is ``boards``,
+meaning a "boards" directory located in the root of the project.
 
 By default, PlatformIO looks for boards in this order:
 
-1. Project :ref:`projectconf_pio_boards_dir`
+1. Project :ref:`projectconf_pio_boards_dir` (as defined by this setting)
 2. Global :ref:`projectconf_pio_core_dir`/boards
 3. Development platform :ref:`projectconf_pio_core_dir`/platforms/\*/boards.
 
@@ -568,8 +570,8 @@ with :option:`platformio remote run --force-remote` or
 - :ref:`projectconf_pio_data_dir`
 - :ref:`projectconf_pio_test_dir`
 
-A default value is ``shared`` that means that folder is located in the root of
-project.
+The default value is ``shared``, meaning a directory named "shared"
+located in the root of the project.
 
 This option can also be configured by the global environment variable
 :envvar:`PLATFORMIO_SHARED_DIR`.


### PR DESCRIPTION
I'm new to PlatformIO so it's very obvious to me when something in the documentation is unclear. I used this as an opportunity to clarify the documentation. Since I don't know the actual code, please review each change I propose and correct if I I got anything wrong.

Here are some main categories of my changes:

Clearer and more fleshed out introduction of terms (such as what's a "platform", what's a "package" etc).

Changed vague directions like "you should use" to the clearer "you must use" or simply "use". When something is not a requirement, the words "optionally" or "may" are better make that fact clear.

Changed some formulations to improve readability; for example changing from:

  "See below available directory ``***_dir`` options."
to
  "See the available directory ``***_dir`` options below."

Other minor language details such as changing "a default value is" to "the default value is" as there is ever only one default value. I added a fair number of "the" to make the language flow more naturally.
