### PR TITLE
Updating URL to Espressif partition table docs

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -174,7 +174,7 @@ See `project example <https://github.com/platformio/platform-espressif32/tree/de
 
 Partition Tables
 ~~~~~~~~~~~~~~~~
-You can create a custom partitions table (CSV) following `ESP32 Partition Tables <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/storage/nvs_partition_gen.html>`_
+You can create a custom partitions table (CSV) following `ESP32 Partition Tables <https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/partition-tables.html>`_
 documentation. PlatformIO uses **default partition tables** depending on a
 :ref:`projectconf_env_framework` type:
 


### PR DESCRIPTION
Reading the PlatformIO docs about Partition Tables I found a URL that points to ESP NVS and how to create an NVS partition but the docs to the actual partition tables. It's a trivial change but hope I can help others with this change.