### PR TITLE
Fix formatting typo

### DIFF
--- a/projectconf.rst
+++ b/projectconf.rst
@@ -18,7 +18,7 @@ Each PlatformIO project has a configuration file named
 ``platformio.ini`` in the root directory for the project. This is a
 `INI-style <http://en.wikipedia.org/wiki/INI_file>`_ file.
 
-``platformio.ini`` has sections (each denoted by a ``[``header``]``) and
+``platformio.ini`` has sections (each denoted by a ``[header]``) and
 key / value pairs within the sections. Lines beginning with ``;``
 are ignored and may be used to provide comments.
 


### PR DESCRIPTION
The "   [header]   "  bit is formatted weird - I think this fixes it
