### PR TITLE
Updated espota -h output for esp8266

### DIFF
--- a/platforms/espressif8266_extra.rst
+++ b/platforms/espressif8266_extra.rst
@@ -441,6 +441,8 @@ For the full list with available options please run
 
     ~/.platformio/packages/tool-espotapy/espota.py --help
 
+    Usage: espota.py [options]
+
     Transmit image over the air to the esp8266 module with OTA support.
 
     Options:
@@ -469,8 +471,6 @@ For the full list with available options please run
       Output:
         -d, --debug         Show debug output. And override loglevel with debug.
         -r, --progress      Show progress output. Does not work for ArduinoIDE
-        -t TIMEOUT, --timeout=TIMEOUT
-                            Timeout to wait for the ESP8266 to accept invitation
 
 Demo
 ~~~~

--- a/platforms/espressif8266_extra.rst
+++ b/platforms/espressif8266_extra.rst
@@ -439,7 +439,7 @@ For the full list with available options please run
 
 .. code-block:: bash
 
-    ~/.platformio/packages/tool-espotapy/espota.py --help
+    ~/.platformio/packages/framework-arduinoespressif8266/tools/espota.py --help
 
     Usage: espota.py [options]
 


### PR DESCRIPTION
Since platform-espressif8266@2.1.0 the platform specific espota tool has been used, which has different parameters to those shown, namely it doesn't have the TIMEOUT parameter.