### PR TITLE
Update espota.py -h output for espressif32

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -378,7 +378,7 @@ For the full list with available options please run
 
 .. code-block:: bash
 
-    ~/.platformio/packages/tool-espotapy/espota.py -h
+    ~/.platformio/packages/framework-arduinoespressif32/tools/espota.py --help
 
     Usage: espota.py [options]
 
@@ -390,8 +390,12 @@ For the full list with available options please run
       Destination:
         -i ESP_IP, --ip=ESP_IP
                             ESP32 IP Address.
+        -I HOST_IP, --host_ip=HOST_IP
+                            Host IP Address.
         -p ESP_PORT, --port=ESP_PORT
-                            ESP32 ota Port. Default 8266
+                            ESP32 ota Port. Default 3232
+        -P HOST_PORT, --host_port=HOST_PORT
+                            Host server ota Port. Default random 10000-60000
 
       Authentication:
         -a AUTH, --auth=AUTH
@@ -406,6 +410,8 @@ For the full list with available options please run
       Output:
         -d, --debug         Show debug output. And override loglevel with debug.
         -r, --progress      Show progress output. Does not work for ArduinoIDE
+        -t TIMEOUT, --timeout=TIMEOUT
+                            Timeout to wait for the ESP32 to accept invitation
 
 .. warning::
     For windows users. To manage OTA check the ESP wifi network profile isn't checked on public


### PR DESCRIPTION
Since platform-espressif32@1.9.0 the platform provided espota.py tool has been used, and the output shown in the docs has incorrectly listed the generic version.