### PR TITLE
Fix wrong variables used for custom bootloader programming

### DIFF
--- a/platforms/atmelavr_extra.rst
+++ b/platforms/atmelavr_extra.rst
@@ -283,14 +283,11 @@ Custom bootloader and corresponding fuses should be specified in :ref:`projectco
     board = uno
 
     board_bootloader.file = /path/to/custom/bootloader.hex
-    board_bootloader.low_fuses = 0xFF
-    board_bootloader.high_fuses = 0xDE
-    board_bootloader.extended_fuses = 0xFD
+    board_bootloader.lfuse = 0xFF
+    board_bootloader.hfuse = 0xDE
+    board_bootloader.efuse = 0xFD
     board_bootloader.lock_bits = 0x0F
     board_bootloader.unlock_bits = 0x3F
-
-
-https://github.com/MCUdude/platformio-docs
 
 ``MiniCore``, ``MegaCore`` and ``MightyCore`` have a wide variety of precompiled bootloaders. Bootloader binary is dynamically selected according to the hardware parameters: ``f_cpu``, ``oscillator``, ``upload_speed``:
 


### PR DESCRIPTION
Changes:
- As in the `boards.txt` (e.g. for the uno: https://github.com/platformio/platform-atmelavr/blob/de57dda3eb6193d19ab51136d3347b8e56933a00/boards/miniatmega328.json#L9-L15) `lfuse`, `hfuse` and `efuse` must be used instead of `low_fuses`, `high_fuses` and `extended_fuses`. Else running `platformio run -t bootloader` will fail with "Missing bootloader fuses!" - see thread: https://community.platformio.org/t/bootloader-target-fails-with-missing-bootloader-fuses-although-set/11684
- Removed GitHub link pointing to a non-existent repository.