### PR TITLE
Fix of type in docs for 'platforms/espressif32'

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -13,7 +13,7 @@ Tutorials
 ---------
 
 * :ref:`tutorial_espressif32_arduino_debugging_unit_testing`
-* `Video: Free Inline Debugging for ESP32 and Arduino Sketches <hhttps://www.youtube.com/watch?v=psMqilqlrRQ>`__
+* `Video: Free Inline Debugging for ESP32 and Arduino Sketches <https://www.youtube.com/watch?v=psMqilqlrRQ>`__
 
 Configuration
 -------------


### PR DESCRIPTION
s/hhttps/https/ in the tutorial links for the docs page: https://docs.platformio.org/en/latest/platforms/espressif32.html