### PR TITLE
Added serial protocol support to BluePill F103C8

### DIFF
--- a/boards/ststm32/bluepill_f103c8.rst
+++ b/boards/ststm32/bluepill_f103c8.rst
@@ -72,6 +72,7 @@ BluePill F103C8 supports the next uploading protocols:
 * ``dfu``
 * ``jlink``
 * ``mbed``
+* ``serial``
 * ``stlink``
 
 Default protocol is ``stlink``


### PR DESCRIPTION
This device supports these uploading protocols: "AVAILABLE: blackmagic, dfu, jlink, mbed, serial, stlink"