### PR TITLE
Update envvars.rst

### DIFF
--- a/envvars.rst
+++ b/envvars.rst
@@ -159,7 +159,7 @@ Building
 
 .. envvar:: PLATFORMIO_BUILD_FLAGS
 
-Allows one to set :ref:`projectconf` option :ref:`projectconf_build_flags`.
+Allows one to set :ref:`projectconf` option :ref:`projectconf_build_flags`. When using special characters, be sure to follow escaping rules for ``Bash`` and ``CMake``.
 
 Examples:
 
@@ -167,13 +167,13 @@ Examples:
 
     # Unix:
     export PLATFORMIO_BUILD_FLAGS=-DFOO
-    export PLATFORMIO_BUILD_FLAGS=-DFOO -DBAR=1 -DFLOAT_VALUE=1.23457e+07
-    export PLATFORMIO_BUILD_FLAGS='-DWIFI_PASS=\"My password\"' '-DWIFI_SSID=\"My ssid name\"'
+    export PLATFORMIO_BUILD_FLAGS='-DFOO -DBAR=1 -DFLOAT_VALUE=1.23457e+07'
+    export PLATFORMIO_BUILD_FLAGS='-D WIFI_SSID=\"My ssid\" -D WIFI_PASS=\"My password\"'
 
     # Windows:
     SET PLATFORMIO_BUILD_FLAGS=-DFOO
     SET PLATFORMIO_BUILD_FLAGS=-DFOO -DBAR=1 -DFLOAT_VALUE=1.23457e+07
-    SET PLATFORMIO_BUILD_FLAGS='-DWIFI_PASS="My password"' '-DWIFI_SSID="My ssid name"'
+    SET PLATFORMIO_BUILD_FLAGS='-D WIFI_SSID="My ssid"' '-D WIFI_PASS="My password"'
 
 .. envvar:: PLATFORMIO_SRC_BUILD_FLAGS
 


### PR DESCRIPTION
Hi there!

I tried to inject my Wifi credentials on Ubuntu 16.04 via platformio's environment build flags by appending each statement to the end of my ``.bashrc`` file. However, the stated Unix examples did not work for me. As I suspect that other systems are affected too, I suggest the following changes to the docs. In detail:

``export PLATFORMIO_BUILD_FLAGS=-DFOO``
(Works)

---

``export PLATFORMIO_BUILD_FLAGS=-DFOO -DBAR=1 -DFLOAT_VALUE=1.23457e+07``
Error when opening a new terminal:
```
bash: export: `-DBAR=1': not a valid identifier
bash: export: `-DFLOAT_VALUE=1.23457e+07': not a valid identifier
```
Adding single quotes around all values fixes this:
``export PLATFORMIO_BUILD_FLAGS='-DFOO -DBAR=1 -DFLOAT_VALUE=1.23457e+07'``

---

``export PLATFORMIO_BUILD_FLAGS='-DWIFI_PASS=\"My password\"' '-DWIFI_SSID=\"My ssid name\"'``
Build flags are cut off after first pair of single quotes. Solution: Enclose all flags in one pair of single quotes:
``export PLATFORMIO_BUILD_FLAGS='-DWIFI_PASS=\"My password\" -DWIFI_SSID=\"My ssid name\"'``

---
(I did not check the flags on Windows)

Additionally: I changed the order of password and ssid flag and added a statement to look out for escaping rules of special characters. E.g.: My password contains a single ``$`` which needs to be escaped like this: ``\$\$``. (Doubling $ for CMake and \ for bash)

Cheers, Reinbert