### PR TITLE
Added hid as upload protocol for the blackpill f103c8

### DIFF
--- a/boards/ststm32/blackpill_f103c8.rst
+++ b/boards/ststm32/blackpill_f103c8.rst
@@ -69,6 +69,7 @@ Uploading
 BlackPill F103C8 supports the next uploading protocols:
 
 * ``blackmagic``
+* ``hid``
 * ``jlink``
 * ``serial``
 * ``stlink``


### PR DESCRIPTION
Figured out pio supports the [HID bootloader](https://github.com/Serasidis/STM32_HID_Bootloader) on this board