### PR TITLE
Rename misc to system in completions

### DIFF
--- a/core/userguide/system/completion/cmd_install.rst
+++ b/core/userguide/system/completion/cmd_install.rst
@@ -12,7 +12,7 @@
 .. _cmd_misc_completion_install:
 
 platformio system completion install
-==================================
+====================================
 
 .. contents::
 

--- a/core/userguide/system/completion/cmd_install.rst
+++ b/core/userguide/system/completion/cmd_install.rst
@@ -11,7 +11,7 @@
 
 .. _cmd_misc_completion_install:
 
-platformio misc completion install
+platformio system completion install
 ==================================
 
 .. contents::
@@ -21,8 +21,8 @@ Usage
 
 .. code-block:: bash
 
-    platformio misc completion install [OPTIONS]
-    pio misc completion install [OPTIONS]
+    platformio system completion install [OPTIONS]
+    pio system completion install [OPTIONS]
 
 
 Description
@@ -33,7 +33,7 @@ Install shell completion files or code.
 Options
 ~~~~~~~
 
-.. program:: platformio misc completion install
+.. program:: platformio system completion install
 
 .. option::
     --shell
@@ -58,7 +58,7 @@ Examples
 
 .. code::
 
-    > pio misc completion install
+    > pio system completion install
 
     PlatformIO CLI completion has been installed for fish shell to ~/.config/fish/completions/pio.fish
     Please restart a current shell session

--- a/core/userguide/system/completion/cmd_uninstall.rst
+++ b/core/userguide/system/completion/cmd_uninstall.rst
@@ -11,7 +11,7 @@
 
 .. _cmd_misc_completion_uninstall:
 
-platformio misc completion uninstall
+platformio system completion uninstall
 ====================================
 
 .. contents::
@@ -21,8 +21,8 @@ Usage
 
 .. code-block:: bash
 
-    platformio misc completion uninstall [OPTIONS]
-    pio misc completion uninstall [OPTIONS]
+    platformio system completion uninstall [OPTIONS]
+    pio system completion uninstall [OPTIONS]
 
 
 Description
@@ -33,7 +33,7 @@ Uninstall shell completion files or code.
 Options
 ~~~~~~~
 
-.. program:: platformio misc completion uninstall
+.. program:: platformio system completion uninstall
 
 .. option::
     --shell
@@ -58,7 +58,7 @@ Examples
 
 .. code::
 
-    > pio misc completion uninstall
+    > pio system completion uninstall
 
     PlatformIO CLI completion has been uninstalled for fish shell from ~/.config/fish/completions/pio.fish
     Please restart a current shell session.

--- a/core/userguide/system/completion/cmd_uninstall.rst
+++ b/core/userguide/system/completion/cmd_uninstall.rst
@@ -12,7 +12,7 @@
 .. _cmd_misc_completion_uninstall:
 
 platformio system completion uninstall
-====================================
+======================================
 
 .. contents::
 

--- a/core/userguide/system/completion/index.rst
+++ b/core/userguide/system/completion/index.rst
@@ -25,9 +25,9 @@ To print all available commands and options use:
 
 .. code-block:: bash
 
-    platformio misc completion --help
-    platformio misc completion COMMAND --help
-    pio misc completion --help
+    platformio system completion --help
+    platformio system completion COMMAND --help
+    pio system completion --help
 
 
 .. toctree::


### PR DESCRIPTION
Fixes completion command examples that still mention `misc` instead of `system`.