### PR TITLE
fix the AZ-Delivery ESP-32 Dev Kit C V4 flash size

### DIFF
--- a/boards/espressif32/az-delivery-devkit-v4.rst
+++ b/boards/espressif32/az-delivery-devkit-v4.rst
@@ -28,7 +28,7 @@ Platform :ref:`platform_espressif32`: Espressif Systems is a privately held fabl
   * - **Frequency**
     - 240MHz
   * - **Flash**
-    - 16MB
+    - 4MB
   * - **RAM**
     - 520KB
   * - **Vendor**


### PR DESCRIPTION
please note that I do not known where I have to change the data that is returned by the `platformio boards` command, so this PR is only for the documentation.

for reference, this board has a 32-Mbit flash which corresponds to 4-MBytes, as you can see with `esptool.py`:

```
$ esptool.py -p /dev/ttyUSB0 flash_id

esptool.py v2.8
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP32
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 24:62:ab:e0:29:3c
Uploading stub...
Running stub...
Stub running...
Manufacturer: 5e
Device: 4016
Detected flash size: 4MB
Hard resetting via RTS pin...
```
