### PR TITLE
Add missing `-d`

### DIFF
--- a/integration/ci/github-actions.rst
+++ b/integration/ci/github-actions.rst
@@ -66,7 +66,7 @@ This variant is default choice for native PlatformIO projects:
             python -m pip install --upgrade pip
             pip install platformio
         - name: Run PlatformIO
-          run: platformio run /path/to/project/dir -e <ID_1> -e <ID_2> -e <ID_N>
+          run: platformio run -d /path/to/project/dir -e <ID_1> -e <ID_2> -e <ID_N>
 
 
 Using :ref:`cmd_ci` command


### PR DESCRIPTION
`platformio run` needs the `-d` parameter when specifying the path to the project.

Is it worth documenting the `$GITHUB_WORKSPACE` variable here also? i.e. as used [here](https://github.com/pfeerick/nRF24L01pScannerOled/blob/master/.github/workflows/main.yml).