### PR TITLE
Fix dynamic build flags example code

### DIFF
--- a/projectconf/section_env_build.rst
+++ b/projectconf/section_env_build.rst
@@ -220,8 +220,12 @@ in the same directory as ``platformio.ini``.
 
     import subprocess
 
-    revision = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip()
-    print("-DPIO_SRC_REV=%s" % revision)
+    revision = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"])
+        .strip()
+        .decode("utf-8")
+    )
+    print("-DGIT_REV='\"%s\"'" % revision)
 
 
 .. _projectconf_src_build_flags:


### PR DESCRIPTION
This fixes two problems with the example code:

1. compilation errors like  `<command-line>:0:9: error: unable to find numeric literal operator 'operator""a5850f'` because the git revision  macro was not properly escaped 
2. The subprocess module returns bytes. In python3 the script would print `-DGIT_REV=b'a5850f'` because it is not properly decoded. The new code works in python2 and python3.