### PR TITLE
Add TI CC13x0 platform documentation

### DIFF
--- a/platforms/index.rst
+++ b/platforms/index.rst
@@ -77,6 +77,7 @@ Embedded
     ststm32
     ststm8
     teensy
+    ticc13x0
     timsp430
     titiva
     wiznet7500


### PR DESCRIPTION
This PR adds TI CC13x0 platform documentation.