### PR TITLE
Typo fix /core/userguide/project/cmd_config.rst

### DIFF
--- a/core/userguide/project/cmd_config.rst
+++ b/core/userguide/project/cmd_config.rst
@@ -55,7 +55,7 @@ Examples
 
 .. code::
 
-    > pio platformio config
+    > pio project config
     Computed project configuration for Tasmota Project
 
     platformio


### PR DESCRIPTION
I found a typo and fixed it.
If you like these changes, please merge them!