### PR TITLE
Setting custom release date is not available to users

### DIFF
--- a/core/userguide/package/cmd_publish.rst
+++ b/core/userguide/package/cmd_publish.rst
@@ -60,10 +60,13 @@ username of the authorized :ref:`pioaccount`.
 .. option::
     --released-at
 
-Custom release date and time in the next format (UTC): 2014-06-13 17:08:52
+Custom release date and time in the next format (UTC): 2014-06-13 17:08:52. 
 
 .. option::
     --private
+
+.. note::
+    The permission to set custom release dates and times is only available to Super Admins. 
 
 Restrict access to a package (will not be available publicly). The default is to publish
 a package publicly.

--- a/core/userguide/package/cmd_publish.rst
+++ b/core/userguide/package/cmd_publish.rst
@@ -60,7 +60,7 @@ username of the authorized :ref:`pioaccount`.
 .. option::
     --released-at
 
-Custom release date and time in the next format (UTC): 2014-06-13 17:08:52. 
+Custom release date and time in the next format (UTC): 2014-06-13 17:08:52
 
 .. option::
     --private


### PR DESCRIPTION
Based on the forum comment linked below, the documentation was a bit misleading.

https://community.platformio.org/t/is-it-limited-to-6-month-that-the-life-of-old-library-on-platformio-system/17319/29?u=pfeerick