### PR TITLE
Clarify remote run docs

### DIFF
--- a/core/userguide/remote/cmd_run.rst
+++ b/core/userguide/remote/cmd_run.rst
@@ -31,7 +31,7 @@ Usage
 Description
 -----------
 
-Process remotely environments which are defined in :ref:`projectconf` file.
+Process environments which are defined in :ref:`projectconf` file remotely.
 By default, :ref:`pioremote` builds project on a host machine and deploy
 final firmware (program) to a remote device (embedded board).
 


### PR DESCRIPTION
Little clarification - I misunderstood the docs first, thought there are special "remote environments" that can be configured in platformio.ini.