### PR TITLE
V2 of this chip has 8MB & other changes

### DIFF
--- a/boards/espressif32/heltec_wifi_kit_32.rst
+++ b/boards/espressif32/heltec_wifi_kit_32.rst
@@ -28,7 +28,7 @@ Platform :ref:`platform_espressif32`: Espressif Systems is a privately held fabl
   * - **Frequency**
     - 240MHz
   * - **Flash**
-    - 4MB
+    - 4MB (8MB at V2)
   * - **RAM**
     - 320KB
   * - **Vendor**


### PR DESCRIPTION
I changed only the table, there are other changes, also to a GPIO Pin, which can be seen here. Maybe there should be an update. (Heltec Wifi Kit 32 V2)

https://heltec-automation-docs.readthedocs.io/en/latest/esp32+arduino/wifi_kit_32/hardware_update_log.html