### PR TITLE
Correct confusion between platforms and frameworks

### DIFF
--- a/librarymanager/config.rst
+++ b/librarymanager/config.rst
@@ -283,7 +283,7 @@ Example:
 
 .. code-block:: javascript
 
-    "frameworks": ["atmelavr", "espressif8266"]
+    "platforms": ["atmelavr", "espressif8266"]
 
 If the library is compatible with the all platforms, then do not declare this field or
 use ``*`` symbol:


### PR DESCRIPTION
The "platforms" section has as a first JSON example "frameworks" in it, not "platforms"

Noticed per https://community.platformio.org/t/possible-error-in-doc/19983. 