### PR TITLE
Update xmc4700_relax_kit.rst

### DIFF
--- a/boards/infineonxmc/xmc4700_relax_kit.rst
+++ b/boards/infineonxmc/xmc4700_relax_kit.rst
@@ -30,7 +30,7 @@ Platform :ref:`platform_infineonxmc`: Infineon has designed the XMC microcontrol
   * - **Flash**
     - 2.00MB
   * - **RAM**
-    - 1.95MB
+    - 352KB
   * - **Vendor**
     - `Infineon <https://www.infineon.com?utm_source=platformio.org&utm_medium=docs>`__
 


### PR DESCRIPTION
Corrected RAM size from 2MB to 352KB as stated in the official datasheets at:
https://www.infineon.com/dgdl/Infineon-XMC4700-XMC4800-DS-v01_01-EN.pdf?fileId=5546d462518ffd850151908ea8db00b3