### PR TITLE
Update GitLab CI examples to use python:3.9 docker image

### DIFF
--- a/integration/ci/gitlab.rst
+++ b/integration/ci/gitlab.rst
@@ -46,7 +46,7 @@ This variant is default choice for native PlatformIO projects:
 
 .. code-block:: yaml
 
-    image: python:2.7
+    image: python:3.9
 
     stages:
      - test
@@ -68,7 +68,7 @@ and boards from command line interface:
 
 .. code-block:: yaml
 
-    image: python:2.7
+    image: python:3.9
 
     stages:
      - test
@@ -90,7 +90,7 @@ Examples
 
 .. code-block:: yaml
 
-    image: python:2.7
+    image: python:3.9
 
     stages:
      - test


### PR DESCRIPTION
The current examples for GitLab CI are using the `python:2.7` docker image, which does not fullfill the requirements for the current platformio version. With `python:2.7` you get the follwing output from the CI build:
```
…
Error: Python 3.6 or later is required for this operation.
…
```

This PR updates the GitLab CI examples and make use of the current stable `python:3.9` docker image.