### PR TITLE
add cache instuctions to GitLab CI examples

### DIFF
--- a/integration/ci/gitlab.rst
+++ b/integration/ci/gitlab.rst
@@ -48,6 +48,15 @@ This variant is default choice for native PlatformIO projects:
 
     image: python:2.7
 
+    variables:
+      PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"
+      PLATFORMIO_CACHE_DIR: "$CI_PROJECT_DIR/.platformio-cache"
+
+    cache:
+      paths:
+        - .pip-cache/
+        - .platformio-cache/
+
     stages:
      - test
 
@@ -70,6 +79,15 @@ and boards from command line interface:
 
     image: python:2.7
 
+    variables:
+      PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"
+      PLATFORMIO_CACHE_DIR: "$CI_PROJECT_DIR/.platformio-cache"
+
+    cache:
+      paths:
+        - .pip-cache/
+        - .platformio-cache/
+
     stages:
      - test
 
@@ -91,6 +109,15 @@ Examples
 .. code-block:: yaml
 
     image: python:2.7
+
+    variables:
+      PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"
+      PLATFORMIO_CACHE_DIR: "$CI_PROJECT_DIR/.platformio-cache"
+
+    cache:
+      paths:
+        - .pip-cache/
+        - .platformio-cache/
 
     stages:
      - test


### PR DESCRIPTION
As GitLab CI is not able to cache files outside the CI project directory, I've updated the GitLab CI examples to show how to use caching for PIP and PlatformIO cache files.