### PR TITLE
Updated version in example and added include

### DIFF
--- a/plus/debug-tools/avr-stub_extra.rst
+++ b/plus/debug-tools/avr-stub_extra.rst
@@ -32,7 +32,7 @@ use avr-stub, the following settings in :ref:`projectconf`:
 
     ; GDB stub implementation
     lib_deps =
-        jdolinay/avr-debugger @ ~1.1
+        jdolinay/avr-debugger @ ~1.4
 
 Where the value in :ref:`projectconf_debug_port` is a serial port connected to your
 board and ``jdolinay/avr-debugger`` is a special library that implements the GDB stub.
@@ -45,6 +45,7 @@ the Arduino framework it might look like this:
 
     #include "Arduino.h"
     #include "avr8-stub.h"
+    #include "app_api.h" // only needed with flash breakpoints
 
     void setup()
     {
@@ -122,7 +123,7 @@ with the appropriate value from the table above, for example:
     debug_port = SERIAL_PORT
 
     lib_deps =
-        jdolinay/avr-debugger @ ~1.1
+        jdolinay/avr-debugger @ ~1.4
 
 
 Debugger limitations


### PR DESCRIPTION

https://docs.platformio.org/en/latest/plus/debug-tools/avr-stub.html

Updated the library dependancy version in example to avoid confusion.
This commit also adds another `"app_api.h"` include to follow the 
official documentation example


I was tinkering with this the other day and was confused about what the latest version was :) 

I wasn't sure to include is this point about `attachInterrupt`, but I will mention it here:

> The debugger needs to handle the INTx interrupt which is in conflict with the `attachInterrupt`
> function in Arduino software library. Small modification of the Arduino library code is required to
> build the program. This is described in Step 6 section of this document.


This point in the platformio documentation

> One external interrupt pin must be reserved for the debugger.

May be good enough, but I was a bit surprised a modification to the Arduino library is needed.