### PR TITLE
Corrected hardware description.

### DIFF
--- a/boards/nordicnrf52/nicla_sense_me.rst
+++ b/boards/nordicnrf52/nicla_sense_me.rst
@@ -19,7 +19,7 @@ Arduino Nicla Sense ME
 Hardware
 --------
 
-Platform :ref:`platform_nordicnrf52`: The nRF52 Series are built for speed to carry out increasingly complex tasks in the shortest possible time and return to sleep, conserving precious battery power. They have a Cortex-M4F processor and are the most capable Bluetooth Smart SoCs on the market.
+Platform :ref:`platform_nordicnrf52`: The nRF52 Series are built for speed to carry out increasingly complex tasks in the shortest possible time and return to sleep, conserving precious battery power. They have a Cortex-M4F processor which makes them quite a capable Bluetooth Smart SoCs.
 
 .. list-table::
 


### PR DESCRIPTION
The nrf52832 is not right now the most capable Bluetooth Smart SoC on the market. Nordic has the nRF5340 which is directly the upgraded generation. The STM32WB family is also more capable than the nrf52 family.