### PR TITLE
Create LionBit  board configurations 

### DIFF
--- a/boards/espressif32/lionbit.rst
+++ b/boards/espressif32/lionbit.rst
@@ -1,0 +1,152 @@
+..  Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+.. _board_espressif32_lionbit:
+
+LionBit
+====================
+
+.. contents::
+
+Hardware
+--------
+
+Platform :ref:`platform_espressif32`: Espressif Systems is a privately held fabless semiconductor company. They provide wireless communications and Wi-Fi chips which are widely used in mobile devices and the Internet of Things applications.
+
+.. list-table::
+
+  * - **Microcontroller**
+    - ESP32
+  * - **Frequency**
+    - 240MHz
+  * - **Flash**
+    - 4MB
+  * - **RAM**
+    - 320KB
+  * - **Vendor**
+    - `LionBit <http://www.lionbit.lk/?utm_source=platformio.org&utm_medium=docs>`__
+
+
+Configuration
+-------------
+
+Please use ``lionbit`` ID for :ref:`projectconf_env_board` option in :ref:`projectconf`:
+
+.. code-block:: ini
+
+  [env:lionbit]
+  platform = espressif32
+  board = lionbit
+  monitor_speed = 115200
+
+You can override default LIONBIT settings per build environment using
+``board_***`` option, where ``***`` is a JSON object path from
+board manifest `lionbit.json <https://github.com/platformio/platform-espressif32/blob/master/boards/lionbit.json>`_. For example,
+``board_build.mcu``, ``board_build.f_cpu``, etc.
+
+.. code-block:: ini
+
+  [env:lionbit]
+  platform = espressif32
+  board = lionbit
+  monitor_speed = 115200
+
+  ; change microcontroller
+  board_build.mcu = esp32
+
+  ; change MCU frequency
+  board_build.f_cpu = 240000000L
+
+
+Uploading
+---------
+lionBit supports the following uploading protocols:
+
+* ``esp-prog``
+* ``espota``
+* ``esptool``
+* ``iot-bus-jtag``
+
+Default protocol is ``esptool``
+
+You can change upload protocol using :ref:`projectconf_upload_protocol` option:
+
+.. code-block:: ini
+
+  [env:lionbit]
+  platform = espressif32
+  board = lionbit
+  monitor_speed = 115200
+
+  upload_protocol = esptool
+
+Debugging
+---------
+
+:ref:`piodebug` - "1-click" solution for debugging with a zero configuration.
+
+.. warning::
+    You will need to install debug tool drivers depending on your system.
+    Please click on compatible debug tool below for the further
+    instructions and configuration information.
+
+You can switch between debugging :ref:`debugging_tools` using
+:ref:`projectconf_debug_tool` option in :ref:`projectconf`.
+
+LIONBIT does not have on-board debug probe but provision is avaialable with the external debug tools. You will need to use/buy one of external probe listed below.
+
+.. list-table::
+  :header-rows:  1
+
+  * - Compatible Tools
+    - On-board
+    - Default
+  * - :ref:`debugging_tool_esp-prog`
+    - 
+    - Yes
+  * - :ref:`debugging_tool_iot-bus-jtag`
+    - 
+    - 
+  * - :ref:`debugging_tool_jlink`
+    - 
+    - 
+  * - :ref:`debugging_tool_minimodule`
+    - 
+    - 
+  * - :ref:`debugging_tool_olimex-arm-usb-ocd`
+    - 
+    - 
+  * - :ref:`debugging_tool_olimex-arm-usb-ocd-h`
+    - 
+    - 
+  * - :ref:`debugging_tool_olimex-arm-usb-tiny-h`
+    - 
+    - 
+  * - :ref:`debugging_tool_olimex-jtag-tiny`
+    - 
+    - 
+  * - :ref:`debugging_tool_tumpa`
+    - 
+    - 
+
+Frameworks
+----------
+.. list-table::
+    :header-rows:  1
+
+    * - Name
+      - Description
+
+    * - :ref:`framework_arduino`
+      - Arduino Wiring-based Framework allows writing cross-platform software to control devices attached to a wide range of Arduino boards to create all kinds of creative coding, interactive objects, spaces or physical experiences
+
+    * - :ref:`framework_espidf`
+      - ESP-IDF is the official development framework for the ESP32 and ESP32-S Series SoCs.


### PR DESCRIPTION
The board is based on wroom32 and with the display.