### PR TITLE
Fix raspberry pi pico documentation typo, double "with" statement

### DIFF
--- a/boards/raspberrypi/pico.rst
+++ b/boards/raspberrypi/pico.rst
@@ -19,7 +19,7 @@ Raspberry Pi Pico
 Hardware
 --------
 
-Platform :ref:`platform_raspberrypi`: RP2040 is a low-cost, high-performance microcontroller device with with a large on-chip memory, symmetric dual-core processor complex, and rich peripheral.
+Platform :ref:`platform_raspberrypi`: RP2040 is a low-cost, high-performance microcontroller device with a large on-chip memory, symmetric dual-core processor complex, and rich peripheral.
 
 .. list-table::
 


### PR DESCRIPTION
Fix raspberry pi pico documentation.