### PR TITLE
Use $HOME instead of ~

### DIFF
--- a/core/installation.rst
+++ b/core/installation.rst
@@ -234,7 +234,7 @@ If you use Bash as your default shell, you can do it by editing either
 
 .. code-block:: shell
 
-    export PATH=$PATH:~/.platformio/penv/bin
+    export PATH=$PATH:$HOME/.platformio/penv/bin
 
 If you use Zsh, you can either edit ``~/.zprofile`` and add the code above, or
 for supporting both, Bash and Zsh, you can first edit ``~/.profile`` and add


### PR DESCRIPTION
Use $HOME instead of ~ (tilde) for home directory in PATH environment variable.
This can manifest in behavior such as https://community.platformio.org/t/pio-home-cant-find-platformio/25617.

See more at https://stackoverflow.com/a/11587382/264970.