### PR TITLE
Update az-delivery-devkit-v4.rst

### DIFF
--- a/boards/espressif32/az-delivery-devkit-v4.rst
+++ b/boards/espressif32/az-delivery-devkit-v4.rst
@@ -28,7 +28,7 @@ Platform :ref:`platform_espressif32`: Espressif Systems is a privately held fabl
   * - **Frequency**
     - 240MHz
   * - **Flash**
-    - 16MB
+    - 4MB
   * - **RAM**
     - 520KB
   * - **Vendor**


### PR DESCRIPTION
Wrong Flash size: only 4MB instead of 16MB