### PR TITLE
Typo: change build_src_fliter to build_src_filter

### DIFF
--- a/projectconf/section_env_build.rst
+++ b/projectconf/section_env_build.rst
@@ -259,7 +259,7 @@ Selectively remove base/initial flags that were set by the development platform.
 
 .. _projectconf_build_src_filter:
 
-``build_src_fliter``
+``build_src_filter``
 ^^^^^^^^^^^^^^^^^^^^
 
 Type: ``String (Templates)`` | Multiple: ``Yes``


### PR DESCRIPTION
There was a typo in the word filter. Previously, it was written fliter.