### PR TITLE
Document custom option name requirements.

### DIFF
--- a/scripting/examples/platformio_ini_custom_options.rst
+++ b/scripting/examples/platformio_ini_custom_options.rst
@@ -12,8 +12,10 @@
 Custom options in ``platformio.ini``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PlatformIO allows you extending project configuration with own data. You can read
-these values later using `ProjectConfig API <https://github.com/platformio/platformio-core/blob/develop/platformio/project/config.py>`__:
+PlatformIO allows you extending project configuration with own data.
+Custom options have to start with ``custom_`` or ``board_`` to not generate a warning that
+the unknown configuration option will be ignored by PlatformIO.
+You can read these values later using `ProjectConfig API <https://github.com/platformio/platformio-core/blob/develop/platformio/project/config.py>`__:
 
 :``ProjectConfig::get(section, option, default=None)``:
     Get an option value for the named section


### PR DESCRIPTION
If custom options don't start with ``custom_`` (or ``board_``),
pio-core will generate a warning here:
https://github.com/platformio/platformio-core/blob/c0cfbe2ce0e62f37708f16b4d5496dad009b6364/platformio/project/config.py#L158