### PR TITLE
Document possible ESP32 filesystem values more clearly

### DIFF
--- a/platforms/espressif32_extra.rst
+++ b/platforms/espressif32_extra.rst
@@ -271,6 +271,8 @@ for example:
     board = ...
     board_build.filesystem = littlefs
 
+Possible  values for ``board_build.filesystem`` are ``spiffs`` (default), ``littlefs`` and ``fatfs``.
+
 To upload SPIFFS image using OTA update please specify ``upload_port`` /
 ``--upload-port`` as IP address or mDNS host name (ending with the ``*.local``).
 


### PR DESCRIPTION
Commit https://github.com/platformio/platform-espressif32/commit/4371944c6bb4c2f662d95b686fdb2d699b2be455 adds the possibility to select `spiffs`, `littlefs` and `fatfs`, but the documentation does not properly reflect these choises of possibl values. In fact, people might read this and when they want to select "FFat" (as in the documentation), they might get the idea that they can write `board_build.filesystem = ffat`, when in fact it is `fatfs`. 

See occurrance of that in https://github.com/platformio/platform-espressif32/issues/570#issuecomment-1122108311.