### PR TITLE
Fix PIO_UNIT_TESTING reference in unit testing documentation

### DIFF
--- a/advanced/unit-testing/structure.rst
+++ b/advanced/unit-testing/structure.rst
@@ -79,7 +79,7 @@ between your "main" and "test" programs, you have 2 options:
    can't split source code.
 
    .. warning::
-       Please note that you will need to use ``#ifdef PIO_UNIT_TESTING`` and ``#endif``
+       Please note that you will need to use ``#ifndef PIO_UNIT_TESTING`` and ``#endif``
        guard to hide non-test related source code. For example, own ``main()``,
        ``setup() / loop()``, or ``app_main()`` functions.
 


### PR DESCRIPTION
The doc suggests adding an `#ifdef PIO_UNIT_TESTING` to hide non-test related code.  This is the wrong way around... you need to wrap non-test related code with `#ifndef` not `#ifdef` so that it's only parsed when PIO_UNIT_TESTING is *not* underway.