### PR TITLE
Board catalog: adafruit_feather_esp32s3 flash size

### DIFF
--- a/boards/espressif32/adafruit_feather_esp32s3.rst
+++ b/boards/espressif32/adafruit_feather_esp32s3.rst
@@ -28,7 +28,7 @@ Platform :ref:`platform_espressif32`: Espressif Systems is a privately held fabl
   * - **Frequency**
     - 240MHz
   * - **Flash**
-    - 4MB
+    - 8MB
   * - **RAM**
     - 320KB
   * - **Vendor**


### PR DESCRIPTION
Adafruit adafruit_feather_esp32s3 (ID: 5323) board has 8MB flash and no PSRAM.

They relaesed also another version of that board with 4MB flash and 2MB PSRAM (ID: 5477) some days ago, which still can not be found in platformio board catalog and has no board definition json yet. This newer board will need a proper name for the json file to avoid confusion between the 2 boards