### PR TITLE
Fix shell-commands.rst

### DIFF
--- a/core/installation/shell-commands.rst
+++ b/core/installation/shell-commands.rst
@@ -77,7 +77,7 @@ open your system terminal app and paste these commands.
 (**PROBABLY requires** administrator access ``sudo``):
 
 .. code-block:: shell
-
+    mkdir -p /usr/local/bin
     ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio
     ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio
     ln -s ~/.platformio/penv/bin/piodebuggdb /usr/local/bin/piodebuggdb

--- a/core/installation/shell-commands.rst
+++ b/core/installation/shell-commands.rst
@@ -68,9 +68,9 @@ open your system terminal app and paste these commands
 
 .. code-block:: shell
 
-    ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio
-    ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio
-    ln -s ~/.platformio/penv/bin/piodebuggdb /usr/local/bin/piodebuggdb
+    ln -s ~/.platformio/penv/bin/platformio ~/.local/bin/platformio
+    ln -s ~/.platformio/penv/bin/pio ~/.local/bin/pio
+    ln -s ~/.platformio/penv/bin/piodebuggdb ~/.local/bin/piodebuggdb
 
 After that, you should be able to run PlatformIO from terminal. No restart is required.
 

--- a/core/installation/shell-commands.rst
+++ b/core/installation/shell-commands.rst
@@ -28,22 +28,22 @@ If you have :ref:`pioide` already installed, you do not need to install
 Unix and Unix-like
 ~~~~~~~~~~~~~~~~~~
 
-In Unix and Unix-like systems, there are multiple ways to achieve this.
-
 Method 1
 ''''''''
 
-You can export the PlatformIO executables' directory to the PATH environmental
-variable. This method will allow you to execute ``platformio`` commands from
-any terminal emulator as long as you're logged in as the user PlatformIO is
-installed and configured for.
+In Unix and Unix-like systems, you can create symbolic links (symlinks) 
+in your ``$HOME/.local/bin/`` directory to the necessary PlatformIO executables.
+This will allow you to execute ``platformio`` commands from any terminal emulator 
+as long as you're logged in as the user PlatformIO is installed and configured for.
 
-If you use Bash as your default shell, you can do it by editing either
-``~/.profile`` or ``~/.bash_profile`` and adding the following line:
+First, if it's not already the case, you should export your ``$HOME/.local/bin/``
+directory to the PATH environmental variable. If you use Bash as your default shell, 
+you can do it by editing either ``~/.profile`` or ``~/.bash_profile`` and adding the
+following line:
 
 .. code-block:: shell
 
-    export PATH=$PATH:$HOME/.platformio/penv/bin
+    export PATH=$PATH:$HOME/.local/bin
 
 If you use Zsh, you can either edit ``~/.zprofile`` and add the code above, or
 for supporting both, Bash and Zsh, you can first edit ``~/.profile`` and add
@@ -53,9 +53,19 @@ the code above, then edit ``~/.zprofile`` and add the following line:
 
     emulate sh -c '. ~/.profile'
 
-After everything's done, just restart your session (log out and log back in) and you're good to go.
-
 If you don't know the difference between the two, check out `this page <https://serverfault.com/questions/261802/what-are-the-functional-differences-between-profile-bash-profile-and-bashrc>`_.
+
+Now that is done, or if ``$HOME/.local/bin/`` was already exported to your PATH environmental
+variable, you can create the symlinks by opening your system terminal app and paste these
+commands.
+
+.. code-block:: shell
+
+    ln -s ~/.platformio/penv/bin/platformio ~/.local/bin/platformio
+    ln -s ~/.platformio/penv/bin/pio ~/.local/bin/pio
+    ln -s ~/.platformio/penv/bin/piodebuggdb ~/.local/bin/piodebuggdb
+
+After everything's done, just restart your session (log out and log back in) and you're good to go.
 
 Method 2
 ''''''''
@@ -63,14 +73,14 @@ Method 2
 You can create system-wide symlinks. This method is not recommended if you have
 multiple users on your computer because the symlinks will be broken for other users
 and they will get errors while executing PlatformIO commands. If that's not a problem,
-open your system terminal app and paste these commands
-(**MAY require** administrator access ``sudo``):
+open your system terminal app and paste these commands.
+(**PROBABLY requires** administrator access ``sudo``):
 
 .. code-block:: shell
 
-    ln -s ~/.platformio/penv/bin/platformio ~/.local/bin/platformio
-    ln -s ~/.platformio/penv/bin/pio ~/.local/bin/pio
-    ln -s ~/.platformio/penv/bin/piodebuggdb ~/.local/bin/piodebuggdb
+    ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio
+    ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio
+    ln -s ~/.platformio/penv/bin/piodebuggdb /usr/local/bin/piodebuggdb
 
 After that, you should be able to run PlatformIO from terminal. No restart is required.
 

--- a/core/installation/shell-commands.rst
+++ b/core/installation/shell-commands.rst
@@ -77,6 +77,7 @@ open your system terminal app and paste these commands.
 (**PROBABLY requires** administrator access ``sudo``):
 
 .. code-block:: shell
+
     mkdir -p /usr/local/bin
     ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio
     ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio


### PR DESCRIPTION
Hi. First off: nice job on platformIO! It's a great project (Especially when there's no `arduino` package anymore on fedora). I just hope that one day you'll be able to get rid of microsoft's evil VScode Cpp extension as discussed [here](https://github.com/platformio/platformio-vscode-ide/issues/1802)

But anyway, here's a commit, which deals with two issues I have with the instructions in `shell-commands.rst`.

1. The first method is causing issues with python. Specifically, adding the `$HOME/.platformio/penv/bin` (wich contains a `python3` symlink) breaks my python install. Without adding this directory to my `$PATH` variable, I'm having some `ModuleNotFoundError` errors i.e. something's wrong with python's virtual environment. I'm not a big python virtual environment expert so I don't know why, but without the directory in the `$PATH` variable everything is fine. To fix this I propose to use `~/.local/bin` instead (which is usually already filled with python files) **and** symlinks.

2. On my freshly installed system, there is no `/usr/share/bin/` directory. According to a quick google search, this is uncommon but can happen. Also according to the warning on `this page` of PlatformIO's documentation, requiring administrator permissions is against the spirit of PlatformIO so I thought about removing the method entirely, but I guess there are some use cases to a system-wide symlinks? When not "logged in as the user PlatformIO is installed and configured for"? Idk but I left it and added a small `mkdir -p` in case others do not have this directory on their systems.