### PR TITLE
Fix: advanced scripting sample-code fails with unvalued `build_flags` >

### DIFF
--- a/scripting/examples/custom_program_name.rst
+++ b/scripting/examples/custom_program_name.rst
@@ -32,8 +32,14 @@ Sometimes is useful to have a different firmware/program name in
 
     Import("env")
 
-    my_flags = env.ParseFlags(env['BUILD_FLAGS'])
-    defines = {k: v for (k, v) in my_flags.get("CPPDEFINES")}
-    # print(defines)
+    build_flags = env.ParseFlags(env["BUILD_FLAGS"])
+    cppdefines = build_flags.get("CPPDEFINES") or {}
+    if cppdefines:
+        cppdefines = dict(
+            # Support "unvalued" defines, like `-DFOO`.
+            (kv_or_k, None) if isinstance(kv_or_k, str) else kv_or_k
+            for kv_or_k in cppdefines
+        )
+    # print(cppdefines)
 
-    env.Replace(PROGNAME="firmware_%s" % defines.get("VERSION"))
+    env.Replace(PROGNAME="firmware_%s" % cppdefines.get("VERSION"))


### PR DESCRIPTION
The sample code given in  ["Custom firmware/program name"](https://docs.platformio.org/en/latest/scripting/examples/custom_program_name.html#)(<= v6.1.0b1)

would fail if `build_flags` contain defines without a value, like:

```ini
[env]
build_flags=
    -DBAR=1
    -DFOO
```

(usually) with `ValueError: too many values to unpack (expected 2)`,
because the original dict-comprehension code cannot parse structs like this
(for my above sample ini-file):

```python
[
  ["BAR", "1"],
  "FOO"
]
```

- Defensively extract `CPPDEFINES` list out of `BUILD_FLAGS`.