### PR TITLE
Add Serial Upload Protocol for BluePill F103C8

### DIFF
--- a/boards/ststm32/bluepill_f103c8.rst
+++ b/boards/ststm32/bluepill_f103c8.rst
@@ -74,6 +74,7 @@ BluePill F103C8 supports the following uploading protocols:
 * ``jlink``
 * ``mbed``
 * ``stlink``
+* ``serial``
 
 Default protocol is ``stlink``
 

--- a/boards/ststm32/bluepill_f103c8.rst
+++ b/boards/ststm32/bluepill_f103c8.rst
@@ -73,8 +73,8 @@ BluePill F103C8 supports the following uploading protocols:
 * ``dfu``
 * ``jlink``
 * ``mbed``
-* ``stlink``
 * ``serial``
+* ``stlink``
 
 Default protocol is ``stlink``
 


### PR DESCRIPTION
Added "serial" as a new upload protocol for BluePill F103C8. Serial Upload Protocol is used when programming BluePill F103C8 using any FTDI programmer.