### PR TITLE
Splt commands in udev rules

### DIFF
--- a/core/installation/udev-rules.rst
+++ b/core/installation/udev-rules.rst
@@ -31,14 +31,12 @@ Please open system Terminal and type
 
 .. code-block:: bash
 
-    # Recommended
     curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
 
 Or you can manually download and copy the file to a destination folder
 
 .. code-block:: bash
 
-    # OR, manually download and copy this file to destination folder
     sudo cp 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules
 
 

--- a/core/installation/udev-rules.rst
+++ b/core/installation/udev-rules.rst
@@ -34,6 +34,10 @@ Please open system Terminal and type
     # Recommended
     curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/master/scripts/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules
 
+Or you can manually download and copy the file to a destination folder
+
+.. code-block:: bash
+
     # OR, manually download and copy this file to destination folder
     sudo cp 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules
 


### PR DESCRIPTION
I separated the `curl` command from the `cp` command in two different code blocks, so that one can copy directly the first line instead of copying both lines : 

![image](https://user-images.githubusercontent.com/20505580/199884877-2115729e-7f54-4903-a39f-78139a5f02f4.png)
