### PR TITLE
Add path for native platform for recent MSYS2 instalations

### DIFF
--- a/platforms/native_extra.rst
+++ b/platforms/native_extra.rst
@@ -28,6 +28,7 @@ manually depending on your operating system:
   .. code::
 
     C:\msys64\mingw64\bin
+    C:\msys64\ucrt64\bin
     C:\msys64\usr\bin
 
 * **Linux** - open the system terminal and run the following commands:


### PR DESCRIPTION
Recent MSYS2 installations are using UCRT64 environment so the path to GCC is different.

See https://www.msys2.org/docs/environments/
