### PR TITLE
Remove board configuration for platform native

### DIFF
--- a/platforms/native.rst
+++ b/platforms/native.rst
@@ -51,12 +51,10 @@ Stable
     ; Latest stable version
     [env:latest_stable]
     platform = native
-    board = ...
 
     ; Custom stable version
     [env:custom_stable]
     platform = native@x.y.z
-    board = ...
 
 Upstream
 ~~~~~~~~
@@ -65,4 +63,3 @@ Upstream
 
     [env:upstream_develop]
     platform = https://github.com/platformio/platform-native.git
-    board = ...


### PR DESCRIPTION
Platform native does not support any board and it must not be set at all.

See https://github.com/platformio/platform-native/issues/23