### PR TITLE
Add info that python virtual environment package is reqd

### DIFF
--- a/faq/install-python.rst
+++ b/faq/install-python.rst
@@ -20,6 +20,12 @@ is installed by default on the all popular OS except Windows.
 Please navigate to official website and `Download the latest Python <https://www.python.org/downloads/>`_
 and install it. Please **READ NOTES BELOW**.
 
+:Linux:
+  If using the recommended install scripts, your Python environment also needs to have
+  the Python Virtual Environment package, e.g. for Ubuntu 22.04
+  
+  ``sudo apt install python3.10-venv``
+
 :macOS:
   Please read the "Important Information" displayed during installation for information
   about SSL/TLS certificate validation and the running the **"Install Certificates.command"**.

--- a/faq/install-python.rst
+++ b/faq/install-python.rst
@@ -22,9 +22,9 @@ and install it. Please **READ NOTES BELOW**.
 
 :Linux:
   If using the recommended install scripts, your Python environment also needs to have
-  the Python Virtual Environment package, e.g. for Ubuntu 22.04
+  the Python Virtual Environment package, e.g. for Ubuntu
   
-  ``sudo apt install python3.10-venv``
+  ``sudo apt install python3-venv``
 
 :macOS:
   Please read the "Important Information" displayed during installation for information


### PR DESCRIPTION
Had trouble installing Core and Ide, and it turns out that I did not have the python venv package installed.

This was not recommended anywhere. (Not sure if I have used the correct terminology, I am no Python expert.)