### PR TITLE
S3's are using the wrong USB config by default

### DIFF
--- a/boards/espressif32/adafruit_feather_esp32s3_nopsram.rst
+++ b/boards/espressif32/adafruit_feather_esp32s3_nopsram.rst
@@ -62,6 +62,12 @@ board manifest `adafruit_feather_esp32s3_nopsram.json <https://github.com/platfo
 
   ; change MCU frequency
   board_build.f_cpu = 240000000L
+  
+  ; make serial port use correct speed
+  monitor_speed = 115200
+  
+  : use the correct USB peripheral, so programming will work
+  build_flags = -DARDUINO_USB_MODE=1
 
 
 Uploading


### PR DESCRIPTION
Setting these two extra parameters will make both programming and Serial work as expected. Ref: https://github.com/espressif/arduino-esp32/issues/6762#issuecomment-1182821492 Without it, the boards won't program without the use of Boot+Reset buttons (to trigger DFU) at the correct moment during programming. With this, programming works as expected. Setting the Serial speed ensures that Serail output won't need a Reset to work.