### PR TITLE
Emphasize the recommendation for version pinning

### DIFF
--- a/core/userguide/pkg/cmd_install.rst
+++ b/core/userguide/pkg/cmd_install.rst
@@ -194,8 +194,9 @@ Registry: Latest Version
 Install the latest package version from the |PIOREGISTRY|.
 
 .. tip::
-    We highly recommend prefixing a version with ``^`` (caret) symbol
-    which will instruct PlatformIO to install the latest compatible version
+    We highly recommend pinning a package to a :ref:`_cmd_pkg_install_specific_version`
+    and to prefix the version with the ``^`` (caret) symbol.
+    This will instruct PlatformIO to install the latest compatible version
     avoiding breaking changes in the future.
     See :ref:`cmd_pkg_install_requirements` for details.
 
@@ -227,6 +228,8 @@ Install the latest package version from the |PIOREGISTRY|.
     .. code:: shell
 
         pio pkg install --tool "platformio/tool-jlink"
+
+.. _cmd_pkg_install_specific_version:
 
 Registry: Specific Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/platforms/espressif32.rst
+++ b/platforms/espressif32.rst
@@ -799,12 +799,13 @@ Stable
 
 .. code-block:: ini
 
-    ; Latest stable version
+    ; Latest stable version, NOT recommended
+    ; Pin the version as shown below
     [env:latest_stable]
     platform = espressif32
     board = ...
 
-    ; Custom stable version
+    ; Specific version
     [env:custom_stable]
     platform = espressif32@x.y.z
     board = ...

--- a/projectconf/sections/env/options/platform/platform.rst
+++ b/projectconf/sections/env/options/platform/platform.rst
@@ -40,6 +40,9 @@ Example of using a `Espressif 32 development platform <https://registry.platform
     platform = espressif32@3.5.0
 
     [env:latest_version]
+    ; not recommended as it does not ensure that 
+    ; - builds are repeatable
+    ; - all developers who checkout the project wil build against the same platform version
     platform = espressif32
 
     [env:development_verion_by_git]
@@ -50,3 +53,8 @@ Example of using a `Espressif 32 development platform <https://registry.platform
 
     [env:specific_git_commit]
     platform = https://github.com/platformio/platform-espressif32.git#f8340a2081a31c2ac8ed2b16907f2a21dc8897d4
+
+
+.. note::
+    We highly recommend pinning the platform to a verison.
+    See :ref:`cmd_pkg_install_requirements` for details.    


### PR DESCRIPTION
Your docs already mention in a couple of places that it is recommended to pin package versions. I thought it could be emphasized even more.