### PR TITLE
Fix sample code

### DIFF
--- a/tutorials/espressif32/espidf_debugging_unit_testing_analysis.rst
+++ b/tutorials/espressif32/espidf_debugging_unit_testing_analysis.rst
@@ -51,97 +51,105 @@ Adding Code to the Generated Project
 
     .. code-block:: c
 
-      /* WiFi softAP Example
+        /*  WiFi softAP Example
 
-        This example code is in the Public Domain (or CC0 licensed, at your option.)
+           This example code is in the Public Domain (or CC0 licensed, at your option.)
 
-        Unless required by applicable law or agreed to in writing, this
-        software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-        CONDITIONS OF ANY KIND, either express or implied.
-      */
+           Unless required by applicable law or agreed to in writing, this
+           software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+           CONDITIONS OF ANY KIND, either express or implied.
+        */
+        #include <string.h>
+        #include "freertos/FreeRTOS.h"
+        #include "freertos/task.h"
+        #include "esp_mac.h"
+        #include "esp_wifi.h"
+        #include "esp_event.h"
+        #include "esp_log.h"
+        #include "nvs_flash.h"
 
-      #include <string.h>
-      #include "freertos/FreeRTOS.h"
-      #include "freertos/task.h"
-      #include "esp_system.h"
-      #include "esp_wifi.h"
-      #include "esp_event.h"
-      #include "esp_log.h"
-      #include "nvs_flash.h"
+        #include "lwip/err.h"
+        #include "lwip/sys.h"
 
-      #include "lwip/err.h"
-      #include "lwip/sys.h"
-      #define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
-      #define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
+        /* The examples use WiFi configuration that you can set via project configuration menu.
 
-      #define EXAMPLE_ESP_WIFI_SSID "mywifissid"
-      #define EXAMPLE_ESP_WIFI_PASS "mywifipass"
-      #define EXAMPLE_MAX_STA_CONN (3)
+           If you'd rather not, just change the below entries to strings with
+           the config you want - ie #define EXAMPLE_WIFI_SSID "mywifissid"
+        */
+        #define EXAMPLE_ESP_WIFI_SSID      "mywifissid"
+        #define EXAMPLE_ESP_WIFI_PASS      "mywifipass"
+        #define EXAMPLE_ESP_WIFI_CHANNEL   CONFIG_ESP_WIFI_CHANNEL
+        #define EXAMPLE_MAX_STA_CONN       4
 
-      static const char *TAG = "wifi softAP";
+        static const char *TAG = "wifi softAP";
 
-      static void wifi_event_handler(void *arg, esp_event_base_t event_base,
-                                    int32_t event_id, void *event_data)
-      {
-        if (event_id == WIFI_EVENT_AP_STACONNECTED)
+        static void wifi_event_handler(void* arg, esp_event_base_t event_base,
+                                            int32_t event_id, void* event_data)
         {
-          wifi_event_ap_staconnected_t *event = (wifi_event_ap_staconnected_t *)event_data;
-          ESP_LOGI(TAG, "station " MACSTR " join, AID=%d",
-                  MAC2STR(event->mac), event->aid);
-        }
-        else if (event_id == WIFI_EVENT_AP_STADISCONNECTED)
-        {
-          wifi_event_ap_stadisconnected_t *event = (wifi_event_ap_stadisconnected_t *)event_data;
-          ESP_LOGI(TAG, "station " MACSTR " leave, AID=%d",
-                  MAC2STR(event->mac), event->aid);
-        }
-      }
-
-      void wifi_init_softap()
-      {
-        esp_netif_init();
-        ESP_ERROR_CHECK(esp_event_loop_create_default());
-
-        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-        ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-
-        ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL));
-
-        wifi_config_t wifi_config = {
-            .ap = {
-                .ssid = EXAMPLE_ESP_WIFI_SSID,
-                .ssid_len = strlen(EXAMPLE_ESP_WIFI_SSID),
-                .password = EXAMPLE_ESP_WIFI_PASS,
-                .max_connection = EXAMPLE_MAX_STA_CONN,
-                .authmode = WIFI_AUTH_WPA_WPA2_PSK},
-        };
-        if (strlen(EXAMPLE_ESP_WIFI_PASS) == 0)
-        {
-          wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+            if (event_id == WIFI_EVENT_AP_STACONNECTED) {
+                wifi_event_ap_staconnected_t* event = (wifi_event_ap_staconnected_t*) event_data;
+                ESP_LOGI(TAG, "station "MACSTR" join, AID=%d",
+                         MAC2STR(event->mac), event->aid);
+            } else if (event_id == WIFI_EVENT_AP_STADISCONNECTED) {
+                wifi_event_ap_stadisconnected_t* event = (wifi_event_ap_stadisconnected_t*) event_data;
+                ESP_LOGI(TAG, "station "MACSTR" leave, AID=%d",
+                         MAC2STR(event->mac), event->aid);
+            }
         }
 
-        ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-        ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config));
-        ESP_ERROR_CHECK(esp_wifi_start());
-
-        ESP_LOGI(TAG, "wifi_init_softap finished. SSID:%s password:%s",
-                EXAMPLE_ESP_WIFI_SSID, EXAMPLE_ESP_WIFI_PASS);
-      }
-
-      void app_main()
-      {
-        // Initialize NVS
-        esp_err_t ret = nvs_flash_init();
-        if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND)
+        void wifi_init_softap(void)
         {
-          ESP_ERROR_CHECK(nvs_flash_erase());
-          ret = nvs_flash_init();
-        }
-        ESP_ERROR_CHECK(ret);
+            ESP_ERROR_CHECK(esp_netif_init());
+            ESP_ERROR_CHECK(esp_event_loop_create_default());
+            esp_netif_create_default_wifi_ap();
 
-        ESP_LOGI(TAG, "ESP_WIFI_MODE_AP");
-        wifi_init_softap();
-      }
+            wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+            ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+            ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
+                                                                ESP_EVENT_ANY_ID,
+                                                                &wifi_event_handler,
+                                                                NULL,
+                                                                NULL));
+
+            wifi_config_t wifi_config = {
+                .ap = {
+                    .ssid = EXAMPLE_ESP_WIFI_SSID,
+                    .ssid_len = strlen(EXAMPLE_ESP_WIFI_SSID),
+                    .channel = EXAMPLE_ESP_WIFI_CHANNEL,
+                    .password = EXAMPLE_ESP_WIFI_PASS,
+                    .max_connection = EXAMPLE_MAX_STA_CONN,
+                    .authmode = WIFI_AUTH_WPA_WPA2_PSK,
+                    .pmf_cfg = {
+                            .required = false,
+                    },
+                },
+            };
+            if (strlen(EXAMPLE_ESP_WIFI_PASS) == 0) {
+                wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+            }
+
+            ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+            ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
+            ESP_ERROR_CHECK(esp_wifi_start());
+
+            ESP_LOGI(TAG, "wifi_init_softap finished. SSID:%s password:%s channel:%d",
+                     EXAMPLE_ESP_WIFI_SSID, EXAMPLE_ESP_WIFI_PASS, EXAMPLE_ESP_WIFI_CHANNEL);
+        }
+
+        void app_main(void)
+        {
+            //Initialize NVS
+            esp_err_t ret = nvs_flash_init();
+            if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+              ESP_ERROR_CHECK(nvs_flash_erase());
+              ret = nvs_flash_init();
+            }
+            ESP_ERROR_CHECK(ret);
+
+            ESP_LOGI(TAG, "ESP_WIFI_MODE_AP");
+            wifi_init_softap();
+        }
 
     .. warning::
         Make sure this new file ``main.c`` is registered as source file using

--- a/tutorials/espressif32/espidf_debugging_unit_testing_analysis.rst
+++ b/tutorials/espressif32/espidf_debugging_unit_testing_analysis.rst
@@ -71,6 +71,8 @@ Adding Code to the Generated Project
 
       #include "lwip/err.h"
       #include "lwip/sys.h"
+      #define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
+      #define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
 
       #define EXAMPLE_ESP_WIFI_SSID "mywifissid"
       #define EXAMPLE_ESP_WIFI_PASS "mywifipass"
@@ -97,7 +99,7 @@ Adding Code to the Generated Project
 
       void wifi_init_softap()
       {
-        tcpip_adapter_init();
+        esp_netif_init();
         ESP_ERROR_CHECK(esp_event_loop_create_default());
 
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();


### PR DESCRIPTION
- `tcpip_adapter_init` replaced by `esp_netif_init` according to [this migration guide](https://docs.espressif.com/projects/esp-idf/en/v4.2.3/esp32/api-reference/network/tcpip_adapter_migration.html)
- not sure where `MAC2STR` and `MACSTR` were originally coming from but they're not available on a fresh project