### PR TITLE
Update esp32-s2-kaluga-1.rst to reflect presence of onboard debugger

### DIFF
--- a/boards/espressif32/esp32-s2-kaluga-1.rst
+++ b/boards/espressif32/esp32-s2-kaluga-1.rst
@@ -73,6 +73,7 @@ Espressif ESP32-S2-Kaluga-1 Kit supports the following uploading protocols:
 * ``esp-prog``
 * ``espota``
 * ``esptool``
+* ``ftdi``
 * ``iot-bus-jtag``
 * ``jlink``
 * ``minimodule``
@@ -107,7 +108,7 @@ Debugging
 You can switch between debugging :ref:`debugging_tools` using
 :ref:`projectconf_debug_tool` option in :ref:`projectconf`.
 
-Espressif ESP32-S2-Kaluga-1 Kit does not have on-board debug probe and **IS NOT READY** for debugging. You will need to use/buy one of external probe listed below.
+Espressif ESP32-S2-Kaluga-1 Kit has an on-board debug probe and **IS READY** for debugging. You don't need to use/buy external debug probe.
 
 .. list-table::
   :header-rows:  1
@@ -124,6 +125,9 @@ Espressif ESP32-S2-Kaluga-1 Kit does not have on-board debug probe and **IS NOT 
   * - :ref:`debugging_tool_esp-prog`
     - 
     - 
+  * - :ref:`debugging_tool_ftdi`
+    - Yes
+    - Yes
   * - :ref:`debugging_tool_iot-bus-jtag`
     - 
     - 


### PR DESCRIPTION
The documentation for the ESP32-S2-KALUGA-1 hardware currently states that no on-board debugger is present, but this board is actually the one that Espressif recommends 

Separate from the documentation, I've [submitted a PR](https://github.com/platformio/platform-espressif32/pull/1185) to the espressif32 platform repo as well to update the ESP32-S2-Kaluga-1 board definition in order to enable use of the onboard debugger. 