### PR TITLE
Fix windows Scripts path in shell-commands.rst

### DIFF
--- a/core/installation/shell-commands.rst
+++ b/core/installation/shell-commands.rst
@@ -91,5 +91,5 @@ Windows
 Please read one of these instructions `How do I set or change the PATH system variable? <https://www.google.com.ua/search?q=how+do+i+set+or+change+the+path+system+variable>`_
 
 You need to edit the system environment variable called ``Path`` and append
-``C:\Users\UserName\.platformio\penv\Scripts;`` path in the beginning of a
+``C:\Users\UserName\.platformio\penv\Scripts\`` path in the beginning of a
 list (please replace ``UserName`` with your account name).


### PR DESCRIPTION
Just a little fix to the path "C:\Users\UserName\.platformio\penv\Scripts\"  changing the ";" to "\\" so the Windows shell is able to properly open all the scripts inside the folder.