### PR TITLE
Adding note about the need of python(3)_venv installation 

### DIFF
--- a/integration/ide/vscode.rst
+++ b/integration/ide/vscode.rst
@@ -47,6 +47,8 @@ Installation
 
 .. image:: ../../_static/images/ide/vscode/platformio-ide-vscode-pkg-installer.png
 
+Note: python_venv / python3_venv needs to be installed to be able to finish extension installation.
+
 Quick Start
 -----------
 


### PR DESCRIPTION
Adding note about the need of python(3)_venv installation to be able to finis installation of PlatformIO extension in VScode.