### PR TITLE
Update ATmega328PB.rst

### DIFF
--- a/boards/atmelavr/ATmega328PB.rst
+++ b/boards/atmelavr/ATmega328PB.rst
@@ -28,9 +28,9 @@ Platform :ref:`platform_atmelavr`: Atmel AVR 8-bit MCUs deliver a unique combina
   * - **Frequency**
     - 16MHz
   * - **Flash**
-    - 32KB
+    - 64KB
   * - **RAM**
-    - 2KB
+    - 4KB
   * - **Vendor**
     - `Microchip <https://www.microchip.com/wwwproducts/en/ATmega328PB?utm_source=platformio.org&utm_medium=docs>`__
 


### PR DESCRIPTION
Based on the linked description this microcontroller should have 64kb of flash and 4kb of ram.

https://www.microchip.com/en-us/product/ATmega328PB?utm_source=platformio.org&utm_medium=docs

(as well as 2kb of eeprom which is twice the previous one memory).

Not sure if you are limiting the specs in order to be compatible with atmega328p ?