### PR TITLE
add documentation explaining how to debug extra_scripts

### DIFF
--- a/scripting/actions.rst
+++ b/scripting/actions.rst
@@ -104,3 +104,21 @@ The ``extra_script.py`` file is located in the same directory as
             "$BUILD_DIR/${PROGNAME}.elf", "$BUILD_DIR/${PROGNAME}.hex"
         ]), "Building $BUILD_DIR/${PROGNAME}.hex")
     )
+
+Debugging extra_scripts:
+------------------
+
+#. create your extra script with `print(sys.argv)` as content
+#. then add a launch json like
+
+``launch.json``:
+.. code-block:: javascript
+    {
+      "name": "Python Debugger: Upload",
+      "type": "debugpy",
+      "request": "launch",
+      "program": ".....\\scons.py",// put first argument of argv here
+      "args": [   ], // and put the rest into this args array
+      "console": "integratedTerminal",
+    }
+

--- a/scripting/actions.rst
+++ b/scripting/actions.rst
@@ -106,14 +106,18 @@ The ``extra_script.py`` file is located in the same directory as
     )
 
 Debugging extra_scripts:
-------------------
+------------------------
+
+
+
 
 #. create your extra script with `print(sys.argv)` as content
 #. then add a launch json like
 
-``launch.json``:
+
 .. code-block:: javascript
-    {
+
+   {
       "name": "Python Debugger: Upload",
       "type": "debugpy",
       "request": "launch",
@@ -121,4 +125,6 @@ Debugging extra_scripts:
       "args": [   ], // and put the rest into this args array
       "console": "integratedTerminal",
     }
+
+
 


### PR DESCRIPTION
since the extra script api documentation seems to be quite sparse
ive decided to at least add some docs on how to debug an extra script.
that way its possible to find out through debugging what methods are available