### PR TITLE
chore: update python to 3.11

### DIFF
--- a/integration/ci/github-actions.rst
+++ b/integration/ci/github-actions.rst
@@ -66,7 +66,7 @@ This variant is default choice for native PlatformIO projects:
             key: ${{ runner.os }}-pio
         - uses: actions/setup-python@v4
           with:
-            python-version: '3.9'
+            python-version: '3.11'
         - name: Install PlatformIO Core
           run: pip install --upgrade platformio
 
@@ -103,7 +103,7 @@ and boards from command line interface:
               key: ${{ runner.os }}-pio
           - uses: actions/setup-python@v4
             with:
-              python-version: '3.9'
+              python-version: '3.11'
           - name: Install PlatformIO Core
             run: pip install --upgrade platformio
 
@@ -157,7 +157,7 @@ Integration for USB_Host_Shield_2.0 project. The ``workflow.yml`` configuration 
             key: ${{ runner.os }}-pio
         - uses: actions/setup-python@v4
           with:
-            python-version: '3.9'
+            python-version: '3.11'
         - name: Install PlatformIO Core
           run: pip install --upgrade platformio
 

--- a/integration/ci/gitlab.rst
+++ b/integration/ci/gitlab.rst
@@ -46,7 +46,7 @@ This variant is default choice for native PlatformIO projects:
 
 .. code-block:: yaml
 
-    image: python:3.9
+    image: python:3.11
 
     cache:
       paths:
@@ -73,7 +73,7 @@ and boards from command line interface:
 
 .. code-block:: yaml
 
-    image: python:3.9
+    image: python:3.11
 
     cache:
       paths:
@@ -100,7 +100,7 @@ Examples
 
 .. code-block:: yaml
 
-    image: python:3.9
+    image: python:3.11
 
     cache:
       paths:

--- a/integration/ci/shippable.rst
+++ b/integration/ci/shippable.rst
@@ -53,7 +53,7 @@ This variant is default choice for native PlatformIO projects:
 
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     install:
         - pip install -U platformio
@@ -73,7 +73,7 @@ and boards from command line interface:
 
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     env:
         - PLATFORMIO_CI_SRC=path/to/source/file.c
@@ -97,7 +97,7 @@ Examples
 
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     env:
         - PLATFORMIO_CI_SRC=examples/Bluetooth/PS3SPP/PS3SPP.ino

--- a/integration/ci/travis.rst
+++ b/integration/ci/travis.rst
@@ -68,7 +68,7 @@ This variant is default choice for native PlatformIO projects:
 
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     sudo: false
@@ -96,7 +96,7 @@ and boards from command line interface:
 
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     sudo: false
@@ -198,7 +198,7 @@ Examples
     dist: focal
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     cache:
@@ -238,7 +238,7 @@ Examples
     dist: focal
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     cache:
@@ -275,7 +275,7 @@ Examples
     dist: focal
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     cache:
@@ -315,7 +315,7 @@ Examples
     dist: focal
     language: python
     python:
-        - "3.9"
+        - "3.11"
 
     # Cache PlatformIO packages using Travis CI container-based infrastructure
     cache:


### PR DESCRIPTION
core focuses on 3.11, so change it here