### PR TITLE
Add GPIO pin numbers to the wiring table

### DIFF
--- a/plus/debug-tools/esp-prog.rst
+++ b/plus/debug-tools/esp-prog.rst
@@ -77,16 +77,16 @@ Wiring Connections
     - GND
     - Digital ground
   * - 2
-    - ESP_TMS
+    - ESP_TMS (GPIO14)
     - Test Mode State
   * - 4
-    - ESP_TCK
+    - ESP_TCK (GPIO13)
     - JTAG Return Test Clock
   * - 6
-    - ESP_TDO
+    - ESP_TDO (GPIO15)
     - Test Data Out
   * - 8
-    - ESP_TDI
+    - ESP_TDI (GPIO12)
     - Test Data In
 
 Tutorials


### PR DESCRIPTION
Used https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/configure-other-jtag.html as reference