### PR TITLE
update uno r4 wifi debugging board info

### DIFF
--- a/boards/renesas-ra/uno_r4_wifi.rst
+++ b/boards/renesas-ra/uno_r4_wifi.rst
@@ -97,13 +97,14 @@ Debugging
 You can switch between debugging :ref:`debugging_tools` using
 :ref:`projectconf_debug_tool` option in :ref:`projectconf`.
 
-Arduino Uno R4 WiFi does not have on-board debug probe and **IS NOT READY** for debugging. You will need to use/buy one of external probe listed below.
+The ESP32 coprocessor is used to provide a CMSIS-DAP interface to the RA4M1 microcontroller. No additional hardware is necessary for debugging, can just connect through USB.
 
 .. list-table::
   :header-rows:  1
 
   * - Compatible Tools
     - On-board
+    - Yes (through ESP32 coprocessor)
     - Default
   * - :ref:`debugging_tool_cmsis-dap`
     - 


### PR DESCRIPTION
The uno r4 can be debugged very easily by just setting the debug tool to cmsis-dap. It is not true that uno r4 wifi is not ready for debugging, it is ready and extremely easy.

I think this is true of any ESP-32 S3 board as well. I don't have one to test functionality, but if someone does the documentation should probably be updated for all of these boards.