### PR TITLE
Update lib_deps.rst

### DIFF
--- a/projectconf/sections/env/options/library/lib_deps.rst
+++ b/projectconf/sections/env/options/library/lib_deps.rst
@@ -21,7 +21,8 @@ Type: ``Package Specification`` | Multiple: ``Yes``
 
 Specify project dependencies using :ref:`cmd_pkg_install_specifications`
 that should be installed automatically to the
-:ref:`projectconf_pio_libdeps_dir` before environment processing.
+:ref:`projectconf_pio_libdeps_dir` before environment processing. 
+Can be left blank.
 
 If you have multiple build environments that depend on the same libraries,
 you can use :ref:`projectconf_section_env` or :ref:`projectconf_interpolation`


### PR DESCRIPTION
specifying "can be left blank", just as a point of reference. I left it blank on a copy+paste platformio.ini template I made, and it successfully compiles. I had to test it to see - it'd be nice to know beforehand if blank is okay for compilation, adding this for the next guy :)