### PR TITLE
Fix windows proxy example

### DIFF
--- a/core/installation/proxy-configuration.rst
+++ b/core/installation/proxy-configuration.rst
@@ -45,5 +45,5 @@ documentation.
   $ export ALL_PROXY="socks5://10.10.1.10:3434"
 
   # Windows
-  set HTTP_PROXY="HTTP_PROXY=http://user:pass@10.10.1.10:3128/"
+  set HTTP_PROXY=http://user:pass@10.10.1.10:3128/
 


### PR DESCRIPTION
The current version of the documentation contains an incorrect example for Windows users to configure a proxy