### PR TITLE
Update override_board_configuration.rst

### DIFF
--- a/scripting/examples/override_board_configuration.rst
+++ b/scripting/examples/override_board_configuration.rst
@@ -42,5 +42,5 @@ hardware VID/PIDs.
     # should be array of VID:PID pairs
     board_config.update("build.hwids", [
       ["0x2341", "0x0243"],  # 1st pair
-      ["0x2A03", "0x0043"].  # 2nd pair, etc.
+      ["0x2A03", "0x0043"],  # 2nd pair, etc.
     ])


### PR DESCRIPTION
When a user copies and pastes the code, they receive an error message if they fail to remove the punctuation. It has now been updated to use a comma instead.