### PR TITLE
Minor typo

### DIFF
--- a/projectconf/sections/env/options/upload/upload_command.rst
+++ b/projectconf/sections/env/options/upload/upload_command.rst
@@ -21,7 +21,7 @@ upload command with arguments and options or mix with :ref:`projectconf_upload_f
 
 In order to use ``upload_command``, ``upload_protocol = custom`` must be specified.
 
-Default upload commands are declared in ``build/main.py`` script file of
+Default upload commands are declared in ``builder/main.py`` script file of
 :ref:`platforms`. See a list with open source
 :ref:`platforms` => https://github.com/topics/platformio-platform
 


### PR DESCRIPTION
at least for `https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py`