### PR TITLE
Set apart group membership change from udev rules file

### DIFF
--- a/core/installation/udev-rules.rst
+++ b/core/installation/udev-rules.rst
@@ -52,23 +52,33 @@ Restart "udev" management tool:
     sudo udevadm trigger
 
 
-Ubuntu/Debian users may need to add own “username” to the “dialout” group if
-they are not “root”, doing this issuing
+After this file is installed, physically unplug and reconnect your board.
+
+
+Alternative using group membership
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of using a udev rules file, Linux users can get write access to the boards
+using system `groups <https://wiki.archlinux.org/title/Users_and_groups>`__.
+
+First, you need to identify which group owns the file corresponding to the serial port communication to the board (the serial port name can be found with :ref:`cmd_device_list`
+  command). For example, the file permissions for the serial port ``/dev/ttyACM0`` can be queried by:
 
 .. code-block:: bash
 
-    sudo usermod -a -G dialout $USER
-    sudo usermod -a -G plugdev $USER
+    ls -l /dev/ttyACM0
+    
+    # prints something like:
+    # crw-rw---- 1 root dialout 166, 0 juil. 10 13:43 /dev/ttyACM0
 
-Similarly, Arch users may need to add their user to the “uucp” group
+In that case, the read/write permission (`rw`) is granted to both the “root” user and members of the “dialout” group. Now, it is possible to grant read/write access to all users (``$ sudo chmod a+rw /dev/ttyACM0``), but this would only last as long as the card remains connected (only the udev rules file mentioned above can make such change permanent).
+
+The alternative permanent solution is to add its own “username” to the “dialout” group, or whichever group name was identified at the preceding step. Typical names are “dialout”, “plugdev” (Debian/Ubuntu, Fedora), or “uucp” (Arch Linux). Adding a user to a group is done by:
 
 .. code-block:: bash
 
-    sudo usermod -a -G uucp $USER
-    sudo usermod -a -G lock $USER
+    sudo usermod -a -G dialout $USERNAME
 
 .. note::
   You will need to log out and log back in again (or reboot) for the user
-  group changes to take effect.
-
-After this file is installed, physically unplug and reconnect your board.
+  group changes to take effect. The effectiveness of the change can be checked with the ``$ id`` shell command.

--- a/core/installation/udev-rules.rst
+++ b/core/installation/udev-rules.rst
@@ -27,7 +27,7 @@ This file must be placed at ``/etc/udev/rules.d/99-platformio-udev.rules``
 (preferred location) or ``/lib/udev/rules.d/99-platformio-udev.rules``
 (required on some broken systems).
 
-Please open system Terminal and type
+Please open the system Terminal and type
 
 .. code-block:: bash
 
@@ -40,7 +40,7 @@ Or you can manually download and copy the file to a destination folder
     sudo cp 99-platformio-udev.rules /etc/udev/rules.d/99-platformio-udev.rules
 
 
-Restart "udev" management tool:
+Restart the "udev" management tool:
 
 .. code-block:: bash
 
@@ -54,7 +54,6 @@ Restart "udev" management tool:
 
 After this file is installed, physically unplug and reconnect your board.
 
-
 Alternative using group membership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -62,7 +61,7 @@ Instead of using a udev rules file, Linux users can get write access to the boar
 using system `groups <https://wiki.archlinux.org/title/Users_and_groups>`__.
 
 First, you need to identify which group owns the file corresponding to the serial port communication to the board (the serial port name can be found with :ref:`cmd_device_list`
-  command). For example, the file permissions for the serial port ``/dev/ttyACM0`` can be queried by:
+command). For example, the file permissions for the serial port ``/dev/ttyACM0`` can be queried by:
 
 .. code-block:: bash
 
@@ -80,5 +79,5 @@ The alternative permanent solution is to add its own “username” to the “di
     sudo usermod -a -G dialout $USERNAME
 
 .. note::
-  You will need to log out and log back in again (or reboot) for the user
-  group changes to take effect. The effectiveness of the change can be checked with the ``$ id`` shell command.
+    You will need to log out and log back in again (or reboot) for the user
+    group changes to take effect. The effectiveness of the change can be checked with the ``$ id`` shell command.


### PR DESCRIPTION
Hi,

In the present state of the doc on [99-platformio-udev.rules](https://docs.platformio.org/en/latest/core/installation/udev-rules.html), it is suggested that, after adding the udev rules file, it *may* be necessary to *also* change group membership (adding its own user to `dialout` or `uucp` group).

Now, unless I miss something, this is more of an alternative:
- either add the udev rules file to grant write access to all users
- or add  its own user to the appropriate group

I've updated the doc in that sense (keeping the udev rule first, and splitting the group change stuff afterwards), also adding a paragraph to guide the reader in finding out the appropriate group name, since it may be board and distro dependent.

Remark: I hope I didn't made too many syntax errors, because I only had access to a text editor with reST syntax highlighting (better than nothing), but I don't have the setup to recompile the doc.