### PR TITLE
Update lib_dir.rst

### DIFF
--- a/projectconf/sections/platformio/options/directory/lib_dir.rst
+++ b/projectconf/sections/platformio/options/directory/lib_dir.rst
@@ -55,5 +55,12 @@ Then in ``src/main.c`` you should use:
 
     // rest of H/C/CPP code
 
+And platformio.ini file [env:] should include:
+
+-- code::
+    lib_deps = 
+        Bar
+        Foo
+
 PlatformIO will find your libraries automatically, configure the
 preprocessor's include paths and build them.


### PR DESCRIPTION
Added additional information to lib_dir use case description about private library inclusion in platform.io [env:] lib_deps
This was required for me to properly use my private libraries in the lib directory.
Information added would help any newcomers with this potential problem.
