### PR TITLE
Use cmd_debug instead of debug target

### DIFF
--- a/projectconf/build_configurations.rst
+++ b/projectconf/build_configurations.rst
@@ -41,7 +41,7 @@ If you need to build a project in ``debug`` configuration, please use one of
 these options:
 
 * Add :ref:`projectconf_build_type` with ``debug`` value to :ref:`projectconf`
-* Use target ``debug`` for the :option:`pio run --target` command.
+* Use :ref:`cmd_debug` command.
 
 .. note::
   :ref:`piodebug` automatically switches to ``debug`` configuration when you do


### PR DESCRIPTION
I noticed that `debug`  is not a valid target. 
`pio debug` is a working option.