### PR TITLE
Fix example in build_flags.rst

### DIFF
--- a/projectconf/sections/env/options/build/build_flags.rst
+++ b/projectconf/sections/env/options/build/build_flags.rst
@@ -181,7 +181,7 @@ for you:
 .. code:: ini
 
   [env:myenv]
-  extra_scripts = myscript.py
+  extra_scripts = pre:myscript.py
 
 **myscript.py**
 


### PR DESCRIPTION
The example did not work as the default extra_script is post and changes to CPPDEFINES in post have no effect.