### PR TITLE
Fix syntax mistake in example code.

### DIFF
--- a/scripting/examples/extra_python_packages.rst
+++ b/scripting/examples/extra_python_packages.rst
@@ -27,7 +27,7 @@ install them into the same virtual environment where :ref:`piocore` is installed
 
 .. code-block:: python
 
-    Import("env")
+    import env
 
     # List installed packages
     env.Execute("$PYTHONEXE -m pip list")


### PR DESCRIPTION
The example contained a basic syntax mistake in a import statement.