### PR TITLE
Update nucleo_u575zi_q.rst

### DIFF
--- a/boards/ststm32/nucleo_u575zi_q.rst
+++ b/boards/ststm32/nucleo_u575zi_q.rst
@@ -30,7 +30,7 @@ Platform :ref:`platform_ststm32`: The STM32 family of 32-bit Flash MCUs based on
   * - **Flash**
     - 2MB
   * - **RAM**
-    - 256KB
+    - 786KB
   * - **Vendor**
     - `ST <https://www.st.com/en/evaluation-tools/nucleo-u575zi-q.html?utm_source=platformio.org&utm_medium=docs>`__
 


### PR DESCRIPTION
Corrected RAM amount. This board has 786KB of RAM, See [here](https://www.st.com/en/microcontrollers-microprocessors/stm32u575zi.html)